### PR TITLE
Remove conflict markers from stake header

### DIFF
--- a/src/pos/stake.h
+++ b/src/pos/stake.h
@@ -49,7 +49,3 @@ inline bool CheckProofOfStake(const CBlock& block, const CBlockIndex* pindexPrev
 }
 
 #endif // BITCOIN_POS_STAKE_H
-<<<<<<< ours
-=======
-
->>>>>>> theirs


### PR DESCRIPTION
## Summary
- clean up leftover merge conflict markers in `src/pos/stake.h`
- ensure the header terminates with `#endif // BITCOIN_POS_STAKE_H`

## Testing
- `python3 test/lint/lint-files.py src/pos/stake.h`


------
https://chatgpt.com/codex/tasks/task_b_689237635428832f9353194d0dea44a9