### PR TITLE
wallet: remove unused kernel hash stub

### DIFF
--- a/src/wallet/bitgoldstaker.cpp
+++ b/src/wallet/bitgoldstaker.cpp
@@ -2,7 +2,6 @@
 #include <wallet/wallet.h>
 #include <logging.h>
 #include <chrono>
-#include <pos/stake.h>
 
 namespace wallet {
 

--- a/src/wallet/bitgoldstaker.h
+++ b/src/wallet/bitgoldstaker.h
@@ -32,9 +32,6 @@ private:
     std::atomic<bool> m_stop{false};
 };
 
-/** Placeholder for stake kernel hash check. */
-bool CheckStakeKernelHash();
-
 } // namespace wallet
 
 #endif // BITCOIN_WALLET_BITGOLDSTAKER_H


### PR DESCRIPTION
## Summary
- drop leftover CheckStakeKernelHash declaration in bitgoldstaker
- trim unneeded include from bitgoldstaker implementation

## Testing
- `ninja -C build test_bitcoin` *(fails: 'TESTNET4' is not a member of 'ChainType')*


------
https://chatgpt.com/codex/tasks/task_b_6894898df6d8832f9d12988e1a343004