### PR TITLE
Implement basic BitGold staking thread and tests

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -118,6 +118,7 @@ add_executable(test_bitcoin
   util_string_tests.cpp
   util_tests.cpp
   util_threadnames_tests.cpp
+  bitgoldstaker_tests.cpp
   util_trace_tests.cpp
   validation_block_tests.cpp
   validation_chainstate_tests.cpp

--- a/src/test/bitgoldstaker_tests.cpp
+++ b/src/test/bitgoldstaker_tests.cpp
@@ -1,0 +1,34 @@
+#include <wallet/bitgoldstaker.h>
+#include <wallet/test/util.h>
+#include <pos/stake.h>
+#include <test/util/setup_common.h>
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(bitgoldstaker_tests, TestChain100Setup)
+
+BOOST_AUTO_TEST_CASE(stake_block_passes_check)
+{
+    // Create a wallet synced with the pre-mined chain
+    auto wallet = wallet::CreateSyncedWallet(*m_node.chain, WITH_LOCK(Assert(m_node.chainman)->GetMutex(), return m_node.chainman->ActiveChain()), coinbaseKey);
+
+    wallet::BitGoldStaker staker(*wallet);
+    staker.Start();
+
+    int start_height = WITH_LOCK(Assert(m_node.chainman)->GetMutex(), return m_node.chainman->ActiveChain().Height());
+    int target_height = start_height + 1;
+    for (int i = 0; i < 50; ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        int h = WITH_LOCK(Assert(m_node.chainman)->GetMutex(), return m_node.chainman->ActiveChain().Height());
+        if (h >= target_height) break;
+    }
+    staker.Stop();
+
+    LOCK(cs_main);
+    CBlockIndex* tip = m_node.chainman->ActiveChain().Tip();
+    CBlock block;
+    BOOST_REQUIRE(m_node.chainman->m_blockman.ReadBlock(block, *tip));
+    const Consensus::Params& consensus = m_node.chainman->GetParams().GetConsensus();
+    BOOST_CHECK(CheckProofOfStake(block, tip->pprev, consensus));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/bitgoldstaker.cpp
+++ b/src/wallet/bitgoldstaker.cpp
@@ -2,6 +2,12 @@
 #include <wallet/wallet.h>
 #include <logging.h>
 #include <chrono>
+#include <interfaces/chain.h>
+#include <node/context.h>
+#include <pos/stake.h>
+#include <pow.h>
+#include <validation.h>
+#include <util/time.h>
 
 namespace wallet {
 
@@ -27,9 +33,132 @@ void BitGoldStaker::Stop()
 
 void BitGoldStaker::ThreadStaker()
 {
+    interfaces::Chain& chain = m_wallet.chain();
+    node::NodeContext* node_context = chain.context();
+    if (!node_context || !node_context->chainman) {
+        LogPrintf("BitGoldStaker: chainman unavailable\n");
+        return;
+    }
+    ChainstateManager& chainman = *node_context->chainman;
+    const Consensus::Params& consensus = chainman.GetParams().GetConsensus();
+
     while (!m_stop) {
-        // Placeholder staking loop. Select UTXOs and evaluate kernel hashes.
-        LogPrintf("BitGoldStaker thread iteration\n");
+        try {
+            std::optional<COutput> stake_out;
+            {
+                LOCK(m_wallet.cs_wallet);
+                for (const COutput& out : AvailableCoins(m_wallet).All()) {
+                    if (!out.spendable || out.depth <= 0) continue;
+                    stake_out = out;
+                    break;
+                }
+            }
+            if (!stake_out) {
+                LogPrintf("BitGoldStaker: no mature UTXOs\n");
+                std::this_thread::sleep_for(std::chrono::seconds(1));
+                continue;
+            }
+
+            LOCK(::cs_main);
+            CBlockIndex* pindexPrev = chainman.ActiveChain().Tip();
+            if (!pindexPrev) {
+                std::this_thread::sleep_for(std::chrono::seconds(1));
+                continue;
+            }
+
+            const CWalletTx* wtx = m_wallet.GetWalletTx(stake_out->outpoint.hash);
+            if (!wtx) {
+                LogPrintf("BitGoldStaker: missing wallet tx\n");
+                std::this_thread::sleep_for(std::chrono::seconds(1));
+                continue;
+            }
+            auto* conf = wtx->state<TxStateConfirmed>();
+            if (!conf) {
+                LogPrintf("BitGoldStaker: staking tx not confirmed\n");
+                std::this_thread::sleep_for(std::chrono::seconds(1));
+                continue;
+            }
+
+            const CBlockIndex* pindexFrom = chainman.m_blockman.LookupBlockIndex(conf->confirmed_block_hash);
+            if (!pindexFrom) {
+                LogPrintf("BitGoldStaker: staking tx block not found\n");
+                std::this_thread::sleep_for(std::chrono::seconds(1));
+                continue;
+            }
+
+            CBlock block_from;
+            block_from.nVersion = pindexFrom->nVersion;
+            block_from.hashPrevBlock = pindexFrom->hashPrev;
+            block_from.hashMerkleRoot = pindexFrom->hashMerkleRoot;
+            block_from.nTime = pindexFrom->nTime;
+            block_from.nBits = pindexFrom->nBits;
+            block_from.nNonce = pindexFrom->nNonce;
+
+            unsigned int nTimeTx = std::max<int64_t>(pindexPrev->GetMedianTimePast() + 1,
+                                                     TicksSinceEpoch<std::chrono::seconds>(NodeClock::now()));
+            unsigned int nBits = GetNextWorkRequired(pindexPrev, nullptr, consensus);
+            uint256 hash_proof;
+            if (!CheckStakeKernelHash(pindexPrev, nBits, block_from, conf->position_in_block,
+                                      wtx->tx, stake_out->outpoint, nTimeTx, hash_proof, false)) {
+                LogPrintf("BitGoldStaker: kernel check failed\n");
+                std::this_thread::sleep_for(std::chrono::seconds(1));
+                continue;
+            }
+
+            CMutableTransaction coinstake;
+            coinstake.nLockTime = pindexPrev->nHeight + 1;
+            coinstake.vin.emplace_back(stake_out->outpoint);
+            coinstake.vin[0].nSequence = CTxIn::SEQUENCE_FINAL;
+            coinstake.vout.resize(2);
+            coinstake.vout[0].SetNull();
+            coinstake.vout[1].nValue = stake_out->txout.nValue + GetBlockSubsidy(pindexPrev->nHeight + 1, consensus);
+            coinstake.vout[1].scriptPubKey = stake_out->txout.scriptPubKey;
+            {
+                LOCK(m_wallet.cs_wallet);
+                if (!m_wallet.SignTransaction(coinstake)) {
+                    LogPrintf("BitGoldStaker: failed to sign coinstake\n");
+                    std::this_thread::sleep_for(std::chrono::seconds(1));
+                    continue;
+                }
+            }
+
+            CMutableTransaction coinbase;
+            coinbase.vin.resize(1);
+            coinbase.vin[0].prevout.SetNull();
+            coinbase.vin[0].nSequence = CTxIn::MAX_SEQUENCE_NONFINAL;
+            coinbase.vin[0].scriptSig = CScript() << (pindexPrev->nHeight + 1) << OP_0;
+            coinbase.vout.resize(1);
+            coinbase.vout[0].nValue = 0;
+            coinbase.nLockTime = pindexPrev->nHeight + 1;
+
+            CBlock block;
+            block.vtx.emplace_back(MakeTransactionRef(std::move(coinbase)));
+            block.vtx.emplace_back(MakeTransactionRef(std::move(coinstake)));
+            block.hashPrevBlock = pindexPrev->GetBlockHash();
+            block.nVersion = chainman.m_versionbitscache.ComputeBlockVersion(pindexPrev, consensus);
+            block.nTime = nTimeTx;
+            block.nBits = GetNextWorkRequired(pindexPrev, &block, consensus);
+            block.nNonce = 0;
+            block.hashMerkleRoot = BlockMerkleRoot(block);
+
+            if (!CheckProofOfStake(block, pindexPrev, consensus)) {
+                LogPrintf("BitGoldStaker: produced block failed CheckProofOfStake\n");
+                std::this_thread::sleep_for(std::chrono::seconds(1));
+                continue;
+            }
+
+            bool new_block{false};
+            if (!chainman.ProcessNewBlock(std::make_shared<const CBlock>(block),
+                                          /*force_processing=*/true, /*min_pow_checked=*/true,
+                                          &new_block)) {
+                LogPrintf("BitGoldStaker: ProcessNewBlock failed\n");
+            } else {
+                LogPrintf("BitGoldStaker: staked block %s\n", block.GetHash().ToString());
+            }
+        } catch (const std::exception& e) {
+            LogPrintf("BitGoldStaker exception: %s\n", e.what());
+        }
+
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
     }
 }


### PR DESCRIPTION
## Summary
- Implement staking loop in `BitGoldStaker` that selects mature UTXOs, verifies kernels via `CheckStakeKernelHash`, constructs coinstake blocks and submits them.
- Add regression test covering staker-produced blocks and integrate into test build.

## Testing
- `cmake .. -DBUILD_TESTS=ON` *(fails: Could not find a package configuration file provided by "Boost")*
- `cmake .. -DBUILD_TESTS=ON` *(after installing dependencies)*
- `cmake --build . --target test_bitcoin -j2` *(fails: ‘TESTNET4’ is not a member of ‘ChainType’)*

------
https://chatgpt.com/codex/tasks/task_b_689490145b9c832faa7c8d07719b196f