### PR TITLE
Add testnet DNS seeds

### DIFF
--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -246,11 +246,13 @@ public:
         consensus.hashGenesisBlock = genesis.GetHash();
 // assert(consensus.hashGenesisBlock == uint256{"000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"});
 // assert(genesis.hashMerkleRoot == uint256{"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"});
-        // No DNS seeds for BitGold
-
         vFixedSeeds.clear();
         vSeeds.clear();
         // nodes with support for servicebits filtering should be at the top
+        vSeeds.emplace_back("testnet-seed.bitcoin.jonasschnelli.ch");
+        vSeeds.emplace_back("seed.tbtc.petertodd.org");
+        vSeeds.emplace_back("seed.testnet.bitcoin.sprovoost.nl");
+        vSeeds.emplace_back("testnet-seed.bluematt.me");
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1, 111);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1, 196);


### PR DESCRIPTION
## Summary
- add DNS seed domains for testnet

## Testing
- `python3 test/lint/lint-files.py src/kernel/chainparams.cpp`
- `python3 test/lint/lint-include-guards.py src/kernel/chainparams.cpp`
- `python3 test/lint/lint-includes.py src/kernel/chainparams.cpp`


------
https://chatgpt.com/codex/tasks/task_b_6894a57ca244832fae8311c75c97596f