### PR TITLE
chore: update testnet genesis block

### DIFF
--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -242,10 +242,10 @@ public:
         m_assumed_blockchain_size = 200;
         m_assumed_chain_state_size = 19;
 
-        genesis = CreateGenesisBlock(1296688602, 414098458, 0x1d00ffff, 1, 50 * COIN);
+        genesis = CreateGenesisBlock(1710000000, 165845, 0x1e0ffff0, 1, 3000000 * COIN);
         consensus.hashGenesisBlock = genesis.GetHash();
-// assert(consensus.hashGenesisBlock == uint256{"000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"});
-// assert(genesis.hashMerkleRoot == uint256{"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"});
+        assert(consensus.hashGenesisBlock == uint256{"0000040004f9014602db7db01927c8cd4ddda840c1b4c5bdc10ba588dc288f93"});
+        assert(genesis.hashMerkleRoot == uint256{"66c868e09d6a774ca6019e4f757f1d4e9aafe9633151111451c8767db6d8dd62"});
         vFixedSeeds.clear();
         vSeeds.clear();
         // nodes with support for servicebits filtering should be at the top


### PR DESCRIPTION
## Summary
- regenerate testnet genesis block with new time, nonce, and difficulty
- restore asserts with updated genesis hash and merkle root

## Testing
- `python3 test/lint/lint-includes.py src/kernel/chainparams.cpp`
- `python3 test/lint/lint-include-guards.py src/kernel/chainparams.cpp`

------
https://chatgpt.com/codex/tasks/task_b_6894a5795ab0832f9df4579c93b41514