### PR TITLE
Switch testnet seeds to BitGold and adjust prefixes

### DIFF
--- a/contrib/seeds/README.md
+++ b/contrib/seeds/README.md
@@ -10,21 +10,16 @@ to addrman with).
 
 Update `MIN_BLOCKS` in  `makeseeds.py` and the `-m`/`--minblocks` arguments below, as needed.
 
-The seeds compiled into the release are created from sipa's, achow101's and luke-jr's
-DNS seed, virtu's crawler, and asmap community AS map data. Run the following commands
-from the `/contrib/seeds` directory:
+The seeds compiled into the release are created from BitGold's DNS seed and
+asmap community AS map data. Run the following commands from the
+`/contrib/seeds` directory:
 
 ```
-curl https://bitcoin.sipa.be/seeds.txt.gz | gzip -dc > seeds_main.txt
-curl https://21.ninja/seeds.txt.gz | gzip -dc >> seeds_main.txt
-curl https://luke.dashjr.org/programs/bitcoin/files/charts/seeds.txt >> seeds_main.txt
-curl https://mainnet.achownodes.xyz/seeds.txt.gz | gzip -dc >> seeds_main.txt
-curl https://signet.achownodes.xyz/seeds.txt.gz | gzip -dc > seeds_signet.txt
-curl https://testnet.achownodes.xyz/seeds.txt.gz | gzip -dc > seeds_test.txt
+curl https://seed.bitgold.org/seeds.txt.gz | gzip -dc > seeds_main.txt
+curl https://testnet-seed.bitgold.org/seeds.txt.gz | gzip -dc > seeds_test.txt
 
 curl https://raw.githubusercontent.com/asmap/asmap-data/main/latest_asmap.dat > asmap-filled.dat
 python3 makeseeds.py -a asmap-filled.dat -s seeds_main.txt > nodes_main.txt
-python3 makeseeds.py -a asmap-filled.dat -s seeds_signet.txt -m 237800 > nodes_signet.txt
 python3 makeseeds.py -a asmap-filled.dat -s seeds_test.txt > nodes_test.txt
 
 python3 generate-seeds.py . > ../../src/chainparamsseeds.h

--- a/contrib/seeds/generate-seeds.py
+++ b/contrib/seeds/generate-seeds.py
@@ -3,7 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 '''
-Script to generate list of seed nodes for kernel/chainparams.cpp.
+Script to generate list of BitGold seed nodes for kernel/chainparams.cpp.
 
 This script expects three text files in the directory that is passed as an
 argument:

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -248,15 +248,13 @@ public:
         assert(genesis.hashMerkleRoot == uint256{"66c868e09d6a774ca6019e4f757f1d4e9aafe9633151111451c8767db6d8dd62"});
         vFixedSeeds.clear();
         vSeeds.clear();
-        // nodes with support for servicebits filtering should be at the top
-        vSeeds.emplace_back("testnet-seed.bitcoin.jonasschnelli.ch");
-        vSeeds.emplace_back("seed.tbtc.petertodd.org");
-        vSeeds.emplace_back("seed.testnet.bitcoin.sprovoost.nl");
-        vSeeds.emplace_back("testnet-seed.bluematt.me");
+        // BitGold-specific testnet seeds
+        vSeeds.emplace_back("testnet-seed.bitgold.org");
+        vSeeds.emplace_back("seed-testnet.bitgold.org");
 
-        base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1, 111);
-        base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1, 196);
-        base58Prefixes[SECRET_KEY] = std::vector<unsigned char>(1, 239);
+        base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1, 65);
+        base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1, 78);
+        base58Prefixes[SECRET_KEY] = std::vector<unsigned char>(1, 193);
         base58Prefixes[EXT_PUBLIC_KEY] = {0x02, 0x41, 0xC6, 0x5A}; // bgpub
         base58Prefixes[EXT_SECRET_KEY] = {0x02, 0x41, 0xB2, 0x1B}; // bgprv
 


### PR DESCRIPTION
## Summary
- replace Bitcoin testnet DNS seeds with BitGold domains
- update testnet base58 prefixes for BitGold
- refresh seed generation docs for BitGold

## Testing
- `python3 test/lint/lint-files.py src/kernel/chainparams.cpp contrib/seeds/README.md contrib/seeds/generate-seeds.py`


------
https://chatgpt.com/codex/tasks/task_b_6895f1cf0e2c832faae62d7a3bd45528