### PR TITLE
docs: update bitgold parameters and staking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,27 @@
-Bitcoin Core integration/staging tree
+BitGold integration/staging tree
 =====================================
 
-https://bitcoincore.org
+https://bitgold.org
 
-For an immediately usable, binary version of the Bitcoin Core software, see
-https://bitcoincore.org/en/download/.
+For an immediately usable, binary version of the BitGold software, see
+https://bitgold.org/en/download/.
 
-What is Bitcoin Core?
+What is BitGold?
 ---------------------
 
-Bitcoin Core connects to the Bitcoin peer-to-peer network to download and fully
-validate blocks and transactions. It also includes a wallet and graphical user
-interface, which can be optionally built.
+BitGold connects to the BitGold peer-to-peer network to download and fully
+validate blocks and transactions. The protocol targets 8-minute block times and
+the block subsidy halves every 90 000 blocks. In addition to proof-of-work,
+BitGold implements proof-of-stake staking so holders can help secure the
+network. The software also includes a wallet and graphical user interface,
+which can be optionally built.
 
-Further information about Bitcoin Core is available in the [doc folder](/doc).
+Further information about BitGold is available in the [doc folder](/doc).
 
 License
 -------
 
-Bitcoin Core is released under the terms of the MIT license. See [COPYING](COPYING) for more
+BitGold is released under the terms of the MIT license. See [COPYING](COPYING) for more
 information or see https://opensource.org/license/MIT.
 
 Development Process
@@ -26,7 +29,7 @@ Development Process
 
 The `master` branch is regularly built (see `doc/build-*.md` for instructions) and tested, but it is not guaranteed to be
 completely stable. [Tags](https://github.com/bitcoin/bitcoin/tags) are created
-regularly from release branches to indicate new official, stable release versions of Bitcoin Core.
+regularly from release branches to indicate new official, stable release versions of BitGold.
 
 The https://github.com/bitcoin-core/gui repository is used exclusively for the
 development of the GUI. Its master branch is identical in all monotree
@@ -35,6 +38,13 @@ that repository unless it is for development reasons.
 
 The contribution workflow is described in [CONTRIBUTING.md](CONTRIBUTING.md)
 and useful hints for developers can be found in [doc/developer-notes.md](doc/developer-notes.md).
+
+Staking
+-------
+
+To participate in BitGold's proof-of-stake, run `bitgoldd` or `bitgold-qt` with
+`-staking=1`, or add `staking=1` to `bitgold.conf`. The staking status can be
+checked with `bitgold-cli getstakinginfo`.
 
 Testing
 -------
@@ -70,7 +80,7 @@ Translations
 ------------
 
 Changes to translations as well as new translations can be submitted to
-[Bitcoin Core's Transifex page](https://explore.transifex.com/bitcoin/bitcoin/).
+[BitGold's Transifex page](https://explore.transifex.com/bitcoin/bitcoin/).
 
 Translations are periodically pulled from Transifex and merged into the git repository. See the
 [translation process](doc/translation_process.md) for details on how this works.

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,45 +1,46 @@
-Bitcoin Core
+BitGold
 =============
 
 Setup
 ---------------------
-Bitcoin Core is the original Bitcoin client and it builds the backbone of the network. It downloads and, by default, stores the entire history of Bitcoin transactions, which requires several hundred gigabytes or more of disk space. Depending on the speed of your computer and network connection, the synchronization process can take anywhere from a few hours to several days or more.
+BitGold is a proof-of-stake cryptocurrency derived from Bitcoin. It targets 8-minute block times and the block subsidy halves every 90 000 blocks. The software downloads and, by default, stores the entire history of BitGold transactions, which requires several hundred gigabytes or more of disk space. Depending on the speed of your computer and network connection, the synchronization process can take anywhere from a few hours to several days or more.
 
-To download Bitcoin Core, visit [bitcoincore.org](https://bitcoincore.org/en/download/).
+To download BitGold, visit [bitgold.org](https://bitgold.org/en/download/).
 
 Running
 ---------------------
-The following are some helpful notes on how to run Bitcoin Core on your native platform.
+The following are some helpful notes on how to run BitGold on your native platform.
 
 ### Unix
 
 Unpack the files into a directory and run:
 
-- `bin/bitcoin-qt` (GUI) or
-- `bin/bitcoind` (headless)
-- `bin/bitcoin` (wrapper command)
+- `bin/bitgold-qt` (GUI) or
+- `bin/bitgoldd` (headless)
+- `bin/bitgold` (wrapper command)
 
-The `bitcoin` command supports subcommands like `bitcoin gui`, `bitcoin node`, and `bitcoin rpc` exposing different functionality. Subcommands can be listed with `bitcoin help`.
+The `bitgold` command supports subcommands like `bitgold gui`, `bitgold node`, and `bitgold rpc` exposing different functionality. Subcommands can be listed with `bitgold help`.
+
+To enable staking, start `bitgoldd` or `bitgold-qt` with `-staking=1` or add `staking=1` to `bitgold.conf`.
 
 ### Windows
 
-Unpack the files into a directory, and then run bitcoin-qt.exe.
+Unpack the files into a directory, and then run bitgold-qt.exe.
 
 ### macOS
 
-Drag Bitcoin Core to your applications folder, and then run Bitcoin Core.
+Drag BitGold to your applications folder, and then run BitGold.
 
 ### Need Help?
 
-* See the documentation at the [Bitcoin Wiki](https://en.bitcoin.it/wiki/Main_Page)
-for help and more information.
+* See the documentation at the [Bitcoin Wiki](https://en.bitcoin.it/wiki/Main_Page) for help and more information.
 * Ask for help on [Bitcoin StackExchange](https://bitcoin.stackexchange.com).
 * Ask for help on #bitcoin on Libera Chat. If you don't have an IRC client, you can use [web.libera.chat](https://web.libera.chat/#bitcoin).
 * Ask for help on the [BitcoinTalk](https://bitcointalk.org/) forums, in the [Technical Support board](https://bitcointalk.org/index.php?board=4.0).
 
 Building
 ---------------------
-The following are developer notes on how to build Bitcoin Core on your native platform. They are not complete guides, but include notes on the necessary libraries, compile flags, etc.
+The following are developer notes on how to build BitGold on your native platform. They are not complete guides, but include notes on the necessary libraries, compile flags, etc.
 
 - [Dependencies](dependencies.md)
 - [macOS Build Notes](build-osx.md)
@@ -56,7 +57,7 @@ The Bitcoin repo's [root README](/README.md) contains relevant information on th
 - [Developer Notes](developer-notes.md)
 - [Productivity Notes](productivity.md)
 - [Release Process](release-process.md)
-- [Source Code Documentation (External Link)](https://doxygen.bitcoincore.org/)
+- [Source Code Documentation (External Link)](https://doxygen.bitgold.org/)
 - [Translation Process](translation_process.md)
 - [Translation Strings Policy](translation_strings_policy.md)
 - [JSON-RPC Interface](JSON-RPC-interface.md)
@@ -88,6 +89,7 @@ The Bitcoin repo's [root README](/README.md) contains relevant information on th
 - [Tor Support](tor.md)
 - [Transaction Relay Policy](policy/README.md)
 - [ZMQ](zmq.md)
+- [Staking](staking.md)
 
 License
 ---------------------

--- a/doc/staking.md
+++ b/doc/staking.md
@@ -1,0 +1,25 @@
+BitGold Staker
+==============
+
+BitGold combines proof-of-work with proof-of-stake. Any node that holds
+mature coins may stake to help secure the network and earn rewards.
+
+## Enabling staking
+
+1. Ensure your wallet contains spendable BitGold outputs.
+2. Start the node with staking enabled:
+
+   ```
+   bitgoldd -staking=1
+   ```
+
+   or add the following line to `bitgold.conf`:
+
+   ```
+   staking=1
+   ```
+3. Use `bitgold-cli getstakinginfo` to verify that your node is staking.
+
+The staker will automatically attempt to create new blocks at the protocol's
+8-minute target spacing. Staking rewards follow BitGold's 90 000-block halving
+schedule.


### PR DESCRIPTION
## Summary
- document BitGold's 8-minute block time, 90k-block halving, and proof-of-stake
- add instructions for enabling and using the BitGold staker

## Testing
- `ctest` *(fails: No test configuration file found)*
- `make check` *(fails: No rule to make target 'check')*

------
https://chatgpt.com/codex/tasks/task_b_6895fa8b519c832fb0d9df10f033474e