### PR TITLE
Add staking failure tests for BitGold staker

### DIFF
--- a/src/test/bitgoldstaker_tests.cpp
+++ b/src/test/bitgoldstaker_tests.cpp
@@ -2,6 +2,12 @@
 #include <wallet/test/util.h>
 #include <pos/stake.h>
 #include <test/util/setup_common.h>
+#include <consensus/amount.h>
+#include <key.h>
+#include <script/standard.h>
+#include <test/util/logging.h>
+#include <wallet/coincontrol.h>
+#include <wallet/spend.h>
 #include <boost/test/unit_test.hpp>
 
 BOOST_FIXTURE_TEST_SUITE(bitgoldstaker_tests, TestChain100Setup)
@@ -29,6 +35,80 @@ BOOST_AUTO_TEST_CASE(stake_block_passes_check)
     BOOST_REQUIRE(m_node.chainman->m_blockman.ReadBlock(block, *tip));
     const Consensus::Params& consensus = m_node.chainman->GetParams().GetConsensus();
     BOOST_CHECK(CheckProofOfStake(block, tip->pprev, consensus));
+}
+
+BOOST_AUTO_TEST_CASE(stake_fails_no_utxos)
+{
+    // Wallet without any matching UTXOs
+    CKey unused_key;
+    unused_key.MakeNewKey(/* compressed = */ true);
+    auto wallet = wallet::CreateSyncedWallet(*m_node.chain,
+        WITH_LOCK(Assert(m_node.chainman)->GetMutex(), return m_node.chainman->ActiveChain()),
+        unused_key);
+
+    wallet::BitGoldStaker staker(*wallet);
+    int start_height = WITH_LOCK(Assert(m_node.chainman)->GetMutex(), return m_node.chainman->ActiveChain().Height());
+    ASSERT_DEBUG_LOG("BitGoldStaker: no eligible UTXOs");
+    staker.Start();
+    std::this_thread::sleep_for(std::chrono::milliseconds(600));
+    staker.Stop();
+    int end_height = WITH_LOCK(Assert(m_node.chainman)->GetMutex(), return m_node.chainman->ActiveChain().Height());
+    BOOST_CHECK_EQUAL(start_height, end_height);
+}
+
+BOOST_AUTO_TEST_CASE(stake_fails_kernel_check)
+{
+    // Wallet with coins but kernel hash does not meet difficulty
+    auto wallet = wallet::CreateSyncedWallet(*m_node.chain,
+        WITH_LOCK(Assert(m_node.chainman)->GetMutex(), return m_node.chainman->ActiveChain()),
+        coinbaseKey);
+
+    {
+        LOCK(cs_main);
+        m_node.chainman->ActiveChain().Tip()->nBits = 0x1;
+    }
+
+    wallet::BitGoldStaker staker(*wallet);
+    int start_height = WITH_LOCK(Assert(m_node.chainman)->GetMutex(), return m_node.chainman->ActiveChain().Height());
+    ASSERT_DEBUG_LOG("BitGoldStaker: kernel check failed");
+    staker.Start();
+    std::this_thread::sleep_for(std::chrono::milliseconds(600));
+    staker.Stop();
+    int end_height = WITH_LOCK(Assert(m_node.chainman)->GetMutex(), return m_node.chainman->ActiveChain().Height());
+    BOOST_CHECK_EQUAL(start_height, end_height);
+}
+
+BOOST_AUTO_TEST_CASE(stake_fails_coin_age_or_depth)
+{
+    // Create wallet with coins
+    auto wallet = wallet::CreateSyncedWallet(*m_node.chain,
+        WITH_LOCK(Assert(m_node.chainman)->GetMutex(), return m_node.chainman->ActiveChain()),
+        coinbaseKey);
+
+    // Create unconfirmed transaction so resulting UTXO has depth 0 and age 0
+    CRecipient recipient{GetScriptForRawPubKey(coinbaseKey.GetPubKey()), 1 * COIN, false};
+    CCoinControl coin_control;
+    auto res = CreateTransaction(*wallet, {recipient}, /*change_pos=*/std::nullopt, coin_control);
+    BOOST_REQUIRE(res);
+    CTransactionRef tx = res->tx;
+    wallet->CommitTransaction(tx, {}, {});
+
+    // Lock all other UTXOs leaving only the unconfirmed output
+    {
+        LOCK(wallet->cs_wallet);
+        for (const COutput& out : AvailableCoins(*wallet).All()) {
+            if (out.outpoint.hash != tx->GetHash()) wallet->LockCoin(out.outpoint);
+        }
+    }
+
+    wallet::BitGoldStaker staker(*wallet);
+    int start_height = WITH_LOCK(Assert(m_node.chainman)->GetMutex(), return m_node.chainman->ActiveChain().Height());
+    ASSERT_DEBUG_LOG("BitGoldStaker: no eligible UTXOs");
+    staker.Start();
+    std::this_thread::sleep_for(std::chrono::milliseconds(600));
+    staker.Stop();
+    int end_height = WITH_LOCK(Assert(m_node.chainman)->GetMutex(), return m_node.chainman->ActiveChain().Height());
+    BOOST_CHECK_EQUAL(start_height, end_height);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary
- add BitGold staker tests for absent UTXOs
- test kernel hash failing difficulty
- test staking fails when UTXO depth or age is insufficient

## Testing
- `cmake -GNinja -B build` *(passed)*
- `cmake --build build --target test_bitcoin -j$(nproc)` *(fails: 'TESTNET4' is not a member of 'ChainType')*


------
https://chatgpt.com/codex/tasks/task_b_6895fa90a33c832f8c8cbf46c6f5f2b1