### PR TITLE
Allow PoW block before PoS activation

### DIFF
--- a/src/pos/stake.h
+++ b/src/pos/stake.h
@@ -1,8 +1,8 @@
 #ifndef BITCOIN_POS_STAKE_H
 #define BITCOIN_POS_STAKE_H
 
-#include <primitives/block.h>
 #include <consensus/params.h>
+#include <primitives/block.h>
 #include <uint256.h>
 
 class CBlockIndex;
@@ -22,6 +22,13 @@ bool CheckStakeKernelHash(const CBlockIndex* pindexPrev, unsigned int nBits,
 inline bool CheckProofOfStake(const CBlock& block, const CBlockIndex* pindexPrev,
                               const Consensus::Params& params)
 {
+    assert(pindexPrev);
+    // Allow the first block after genesis (height 1) to be mined with
+    // proof-of-work for initial supply before proof-of-stake activates.
+    if (pindexPrev->nHeight < 1) {
+        return true;
+    }
+
     if (block.vtx.size() < 2) {
         return false; // Needs coinbase and coinstake
     }


### PR DESCRIPTION
## Summary
- permit proof-of-work at height 1 so the chain can distribute its initial supply before switching to proof-of-stake

## Testing
- `cmake -GNinja -B build` *(failed: missing Boost)*
- `apt-get update`
- `apt-get install -y build-essential libboost-dev`
- `apt-get install -y libevent-dev`
- `cmake -GNinja -B build`
- `ninja -C build` *(failed: subcommand failed during build)*

------
https://chatgpt.com/codex/tasks/task_b_6896099d08cc832f82eb2707b3eaf8b4