### PR TITLE
Implement PoS kernel checks and contextual stake validation

### DIFF
--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -1029,9 +1029,12 @@ bool BlockManager::ReadBlock(CBlock& block, const FlatFilePos& pos, const std::o
         LOCK(cs_main);
         prev_index = LookupBlockIndex(block.hashPrevBlock);
     }
-    if (prev_index && !CheckProofOfStake(block, prev_index, GetConsensus())) {
-        LogError("Errors in block proof-of-stake at %s while reading block", pos.ToString());
-        return false;
+    if (prev_index) {
+        if (block.vtx.size() < 2 || block.vtx[1]->vin.empty() || block.vtx[1]->vout.empty() ||
+            !block.vtx[1]->vout[0].IsNull()) {
+            LogError("Errors in block proof-of-stake at %s while reading block", pos.ToString());
+            return false;
+        }
     }
 
     if (expected_hash && block_hash != *expected_hash) {

--- a/src/pos/stake.h
+++ b/src/pos/stake.h
@@ -1,53 +1,35 @@
 #ifndef BITCOIN_POS_STAKE_H
 #define BITCOIN_POS_STAKE_H
 
+#include <consensus/amount.h>
+#include <chain.h>
+#include <coins.h>
 #include <consensus/params.h>
 #include <primitives/block.h>
 #include <uint256.h>
 
 class CBlockIndex;
 
+// Timestamp granularity for staked blocks (16 seconds)
+static constexpr unsigned int STAKE_TIMESTAMP_MASK = 0xF;
+// Minimum coin age for staking (1 hour)
+static constexpr int64_t MIN_STAKE_AGE = 60 * 60;
+
 /** Check that the kernel for a stake meets the required target */
 bool CheckStakeKernelHash(const CBlockIndex* pindexPrev, unsigned int nBits,
-                          const CBlock& blockFrom, unsigned int nTxPrevOffset,
-                          const CTransactionRef& txPrev, const COutPoint& prevout,
+                          uint256 hashBlockFrom, unsigned int nTimeBlockFrom,
+                          CAmount amount, const COutPoint& prevout,
                           unsigned int nTimeTx, uint256& hashProofOfStake,
                           bool fPrintProofOfStake);
 
 /**
- * Validate the proof-of-stake for a block. The block must include a coinstake
- * transaction whose inputs have matured enough time, and the stake kernel hash
- * must satisfy the network difficulty.
+ * Validate the proof-of-stake for a block using contextual chain information.
+ * The block must include a coinstake transaction whose input exists in the
+ * UTXO set and has matured enough time. The stake kernel hash must satisfy the
+ * network difficulty.
  */
-inline bool CheckProofOfStake(const CBlock& block, const CBlockIndex* pindexPrev,
-                              const Consensus::Params& params)
-{
-    assert(pindexPrev);
-    // Allow the first block after genesis (height 1) to be mined with
-    // proof-of-work for initial supply before proof-of-stake activates.
-    if (pindexPrev->nHeight < 1) {
-        return true;
-    }
-
-    if (block.vtx.size() < 2) {
-        return false; // Needs coinbase and coinstake
-    }
-
-    const CTransactionRef& tx = block.vtx[1];
-    if (tx->vin.empty() || tx->vout.empty() || !tx->vout[0].IsNull()) {
-        return false;
-    }
-
-    uint256 hashProofOfStake;
-    const COutPoint& prevout = tx->vin[0].prevout;
-
-    // Enforce difficulty by verifying the stake kernel hash.
-    if (!CheckStakeKernelHash(pindexPrev, block.nBits, block, 1, tx,
-                              prevout, block.nTime, hashProofOfStake, false)) {
-        return false;
-    }
-
-    return true;
-}
+bool ContextualCheckProofOfStake(const CBlock& block, const CBlockIndex* pindexPrev,
+                                 const CCoinsViewCache& view, const CChain& chain,
+                                 const Consensus::Params& params);
 
 #endif // BITCOIN_POS_STAKE_H


### PR DESCRIPTION
## Summary
- implement stake kernel hash with stake modifier, amount-weighted target, coin age and timestamp mask
- update staker and miner to use new kernel API and contextual proof-of-stake check
- add contextual proof-of-stake verifier and minimal block read shape check

## Testing
- `cmake -GNinja ..` *(fails: “TESTNET4 is not a member of ChainType”)*
- `ninja test_bitcoin` *(fails: “TESTNET4 is not a member of ChainType”)*


------
https://chatgpt.com/codex/tasks/task_b_6897d6558614832fa179868c18ef760e