### PR TITLE
Add basic PoS validator and slashing skeleton

### DIFF
--- a/src/pos/slashing.cpp
+++ b/src/pos/slashing.cpp
@@ -1,0 +1,14 @@
+#include "pos/slashing.h"
+
+namespace pos {
+
+bool SlashingTracker::DetectDoubleSign(const std::string& validator_id)
+{
+    if (m_seen.count(validator_id)) {
+        return true;
+    }
+    m_seen.insert(validator_id);
+    return false;
+}
+
+} // namespace pos

--- a/src/pos/slashing.h
+++ b/src/pos/slashing.h
@@ -1,0 +1,21 @@
+#ifndef BITCOIN_POS_SLASHING_H
+#define BITCOIN_POS_SLASHING_H
+
+#include <set>
+#include <string>
+
+namespace pos {
+
+// Tracks validator evidence to detect double-signing events.
+class SlashingTracker {
+public:
+    // Returns true if the validator was seen before (double-sign detected).
+    bool DetectDoubleSign(const std::string& validator_id);
+
+private:
+    std::set<std::string> m_seen;
+};
+
+} // namespace pos
+
+#endif // BITCOIN_POS_SLASHING_H

--- a/src/pos/validator.cpp
+++ b/src/pos/validator.cpp
@@ -1,0 +1,23 @@
+#include "pos/validator.h"
+
+namespace pos {
+
+Validator::Validator(uint64_t stake_amount)
+    : m_stake_amount(stake_amount),
+      m_locked_until(0),
+      m_active(false) {}
+
+void Validator::Activate(int64_t current_time)
+{
+    if (m_stake_amount >= MIN_STAKE && current_time >= m_locked_until) {
+        m_active = true;
+    }
+}
+
+void Validator::ScheduleUnstake(int64_t current_time)
+{
+    m_locked_until = current_time + UNSTAKE_DELAY;
+    m_active = false;
+}
+
+} // namespace pos

--- a/src/pos/validator.h
+++ b/src/pos/validator.h
@@ -1,0 +1,32 @@
+#ifndef BITCOIN_POS_VALIDATOR_H
+#define BITCOIN_POS_VALIDATOR_H
+
+#include <cstdint>
+
+namespace pos {
+
+// Simplified validator representation for Proof-of-Stake systems.
+class Validator {
+public:
+    explicit Validator(uint64_t stake_amount);
+
+    // Attempt to activate the validator if stake and time requirements are met.
+    void Activate(int64_t current_time);
+
+    // Schedule an unstake request; validator becomes inactive until time passes.
+    void ScheduleUnstake(int64_t current_time);
+
+    bool IsActive() const { return m_active; }
+
+private:
+    uint64_t m_stake_amount;
+    int64_t m_locked_until;
+    bool m_active;
+};
+
+constexpr uint64_t MIN_STAKE = 1000;
+constexpr int64_t UNSTAKE_DELAY = 60 * 60 * 24 * 7; // one week
+
+} // namespace pos
+
+#endif // BITCOIN_POS_VALIDATOR_H


### PR DESCRIPTION
## Summary
- add minimal Proof-of-Stake validator class with activation and unstake scheduling
- introduce slashing tracker to detect double-sign evidence

## Testing
- `make check` *(fails: No rule to make target 'check')*
- `cmake -B build` *(fails: Could not find Boost configuration)*

------
https://chatgpt.com/codex/tasks/task_b_6897de4d5528832f82aa5da3d6ca231f