### PR TITLE
Release cs_main before staking loop and drop nested locks

### DIFF
--- a/src/wallet/bitgoldstaker.cpp
+++ b/src/wallet/bitgoldstaker.cpp
@@ -78,8 +78,11 @@ void BitGoldStaker::ThreadStaker()
             if (candidates.empty()) {
                 LogPrintf("BitGoldStaker: no eligible UTXOs\n");
             } else {
-                LOCK(::cs_main);
-                CBlockIndex* pindexPrev = chainman.ActiveChain().Tip();
+                CBlockIndex* pindexPrev{nullptr};
+                {
+                    LOCK(::cs_main);
+                    pindexPrev = chainman.ActiveChain().Tip();
+                }
                 if (!pindexPrev) {
                     LogPrintf("BitGoldStaker: no tip block\n");
                 } else {
@@ -146,14 +149,11 @@ void BitGoldStaker::ThreadStaker()
                         block.nNonce = 0;
                         block.hashMerkleRoot = BlockMerkleRoot(block);
 
-                        {
-                            LOCK(cs_main);
-                            if (!ContextualCheckProofOfStake(block, pindexPrev,
-                                                              chainman.ActiveChainstate().CoinsTip(),
-                                                              chainman.ActiveChain(), consensus)) {
-                                LogPrintf("BitGoldStaker: produced block failed CheckProofOfStake\n");
-                                continue;
-                            }
+                        if (!ContextualCheckProofOfStake(block, pindexPrev,
+                                                          chainman.ActiveChainstate().CoinsTip(),
+                                                          chainman.ActiveChain(), consensus)) {
+                            LogPrintf("BitGoldStaker: produced block failed CheckProofOfStake\n");
+                            continue;
                         }
 
                         bool new_block{false};


### PR DESCRIPTION
## Summary
- Limit cs_main lock scope to fetching the current tip before staking begins
- Remove nested cs_main lock around proof-of-stake checks
- Call ProcessNewBlock only after cs_main is released

## Testing
- `cmake -GNinja ..`
- `ninja bitcoind` *(fails: build stopped: interrupted by user)*

------
https://chatgpt.com/codex/tasks/task_b_689b4c83ca24832f9bf5dc38e7b9e6da