### PR TITLE
Add ActiveChainstate getter for ChainstateManager

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1977,6 +1977,12 @@ void CoinsViews::InitCache()
     m_cacheview = std::make_unique<CCoinsViewCache>(&m_catcherview);
 }
 
+Chainstate& ChainstateManager::ActiveChainstate() const
+{
+    Assert(m_active_chainstate);
+    return *m_active_chainstate;
+}
+
 Chainstate::Chainstate(
     CTxMemPool* mempool,
     BlockManager& blockman,


### PR DESCRIPTION
## Summary
- define `ChainstateManager::ActiveChainstate()` and assert the pointer is valid

## Testing
- `cmake -S . -B build -GNinja`
- `ninja -C build bitcoind` *(fails: undefined reference to CalculateStakePriority)*

------
https://chatgpt.com/codex/tasks/task_b_689b56457348832f946bda83fc45c65e