### PR TITLE
Add staking monitor script

### DIFF
--- a/contrib/stake_monitor.py
+++ b/contrib/stake_monitor.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Monitor block intervals and scan staking logs for kernel failures."""
+
+import json
+import subprocess
+from pathlib import Path
+
+THRESHOLD_SECONDS = 8 * 60  # eight minutes
+
+
+def rpc(*args: str) -> bytes:
+    """Invoke bitcoin-cli and return stdout."""
+    return subprocess.check_output(["bitcoin-cli", *args])
+
+
+def get_block_time(height: int) -> int:
+    block_hash = rpc("getblockhash", str(height)).decode().strip()
+    header = json.loads(rpc("getblockheader", block_hash).decode())
+    return header["time"]
+
+
+def check_interval() -> None:
+    height = int(rpc("getblockcount").strip())
+    if height < 1:
+        print("Not enough blocks to compute interval.")
+        return
+    t_prev = get_block_time(height - 1)
+    t_curr = get_block_time(height)
+    interval = t_curr - t_prev
+    print(f"Block interval: {interval} seconds")
+    if interval > THRESHOLD_SECONDS:
+        print("Interval exceeds eight minutes; scanning debug.log for kernel failures...")
+        log_path = Path.home() / ".bitcoin" / "debug.log"
+        if log_path.exists():
+            with log_path.open("r", encoding="utf8") as fh:
+                kernel_lines = [line.strip() for line in fh if "kernel" in line.lower()]
+            for line in kernel_lines[-10:]:
+                print(line)
+        else:
+            print(f"No log file found at {log_path}")
+
+
+if __name__ == "__main__":
+    check_interval()

--- a/doc/staking.md
+++ b/doc/staking.md
@@ -23,3 +23,17 @@ mature coins may stake to help secure the network and earn rewards.
 The staker will automatically attempt to create new blocks at the protocol's
 8-minute target spacing. Staking rewards follow BitGold's 90 000-block halving
 schedule.
+
+## Monitoring block production
+
+Use `bitgold-cli getblockheader` or `bitgold-cli getblockchaininfo` to inspect
+recent block timestamps. If the interval between consecutive blocks exceeds
+roughly eight minutes, check `debug.log` for entries mentioning `kernel` that
+indicate failed stake evaluations. Reducing stake difficulty or adding more
+mature inputs to the wallet can improve block production.
+
+The helper script `contrib/stake_monitor.py` automates this check:
+
+```
+$ python3 contrib/stake_monitor.py
+```


### PR DESCRIPTION
## Summary
- add `contrib/stake_monitor.py` to warn when block intervals exceed eight minutes and search `debug.log` for staking kernel failures
- document how to monitor block production via `bitgold-cli`

## Testing
- `ruff check contrib/stake_monitor.py`
- `python3 -m py_compile contrib/stake_monitor.py`


------
https://chatgpt.com/codex/tasks/task_b_689cb294f194832f948ea2fb74930c06