### PR TITLE
Fix rpc_generate test parameter

### DIFF
--- a/test/functional/rpc_generate.py
+++ b/test/functional/rpc_generate.py
@@ -39,7 +39,7 @@ class RPCGenerateTest(BitcoinTestFramework):
 
         self.log.info('Generate an empty block to address')
         hash = self.generateblock(node, output=address, transactions=[])['hash']
-        block = node.getblock(blockhash=hash, verbose=2)
+        block = node.getblock(blockhash=hash, verbosity=2)
         assert_equal(len(block['tx']), 1)
         assert_equal(block['tx'][0]['vout'][0]['scriptPubKey']['address'], address)
 


### PR DESCRIPTION
## Summary
- use the correct `verbosity` argument when retrieving a generated block in functional tests

## Testing
- `ninja -C build test_bitcoin` *(fails: build halted around 191/483 steps)*

------
https://chatgpt.com/codex/tasks/task_b_689cbd86e76c832f9799ac0c75967aff