### PR TITLE
Rename Bitcoin Core references to BitGold

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ get_directory_property(precious_variables CACHE_VARIABLES)
 #=============================
 # Project / Package metadata
 #=============================
-set(CLIENT_NAME "Bitcoin Core")
+set(CLIENT_NAME "BitGold")
 set(CLIENT_VERSION_MAJOR 29)
 set(CLIENT_VERSION_MINOR 99)
 set(CLIENT_VERSION_BUILD 0)
@@ -50,7 +50,7 @@ set(CMAKE_TRY_COMPILE_PLATFORM_VARIABLES
   CMAKE_CXX_LINK_EXECUTABLE
 )
 
-project(BitcoinCore
+project(BitGold
   VERSION ${CLIENT_VERSION_MAJOR}.${CLIENT_VERSION_MINOR}.${CLIENT_VERSION_BUILD}
   DESCRIPTION "Bitcoin client software"
   HOMEPAGE_URL "https://bitcoincore.org/"
@@ -545,7 +545,7 @@ else()
   try_append_linker_flag("-Wl,--high-entropy-va" TARGET core_interface)
   try_append_linker_flag("-Wl,-z,relro" TARGET core_interface)
   try_append_linker_flag("-Wl,-z,now" TARGET core_interface)
-  # TODO: This can be dropped once Bitcoin Core no longer supports
+  # TODO: This can be dropped once BitGold no longer supports
   #       NetBSD 10.0 or if upstream fix is backported.
   # NetBSD's dynamic linker ld.elf_so < 11.0 supports exactly 2
   # `PT_LOAD` segments and binaries linked with `-z separate-code`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
-Contributing to Bitcoin Core
-============================
+Contributing to BitGold
+=======================
 
-The Bitcoin Core project operates an open contributor model where anyone is
+The BitGold project operates an open contributor model where anyone is
 welcome to contribute towards development in the form of peer review, testing
 and patches. This document explains the practical process and guidelines for
 contributing.
 
-First, in terms of structure, there is no particular concept of "Bitcoin Core
+First, in terms of structure, there is no particular concept of "BitGold
 developers" in the sense of privileged people. Open source often naturally
 revolves around a meritocracy where contributors earn trust from the developer
 community over time. Nevertheless, some hierarchy is necessary for practical
@@ -24,9 +24,9 @@ as a new contributor. It also will teach you much more about the code and
 process than opening pull requests. Please refer to the [peer review](#peer-review)
 section below.
 
-Before you start contributing, familiarize yourself with the Bitcoin Core build
+Before you start contributing, familiarize yourself with the BitGold build
 system and tests. Refer to the documentation in the repository on how to build
-Bitcoin Core and how to run the unit tests, functional tests, and fuzz tests.
+BitGold and how to run the unit tests, functional tests, and fuzz tests.
 
 There are many open issues of varying difficulty waiting to be fixed.
 If you're looking for somewhere to start contributing, check out the
@@ -36,7 +36,7 @@ list or changes that are
 Some of them might no longer be applicable. So if you are interested, but
 unsure, you might want to leave a comment on the issue first.
 
-You may also participate in the [Bitcoin Core PR Review Club](https://bitcoincore.reviews/).
+You may also participate in the [PR Review Club](https://bitcoincore.reviews/).
 
 ### Good First Issue Label
 
@@ -54,7 +54,7 @@ and is also an effective way to request assistance if and when you need it.
 Communication Channels
 ----------------------
 
-Most communication about Bitcoin Core development happens on IRC, in the
+Most communication about BitGold development happens on IRC, in the
 `#bitcoin-core-dev` channel on Libera Chat. The easiest way to participate on IRC is
 with the web client, [web.libera.chat](https://web.libera.chat/#bitcoin-core-dev). Chat
 history logs can be found
@@ -171,7 +171,7 @@ mailing list discussions).
 The description for a new pull request should not contain any `@` mentions. The
 PR description will be included in the commit message when the PR is merged and
 any users mentioned in the description will be annoyingly notified each time a
-fork of Bitcoin Core copies the merge. Instead, make any username mentions in a
+fork of BitGold copies the merge. Instead, make any username mentions in a
 subsequent comment to the PR.
 
 ### Translation changes
@@ -290,11 +290,11 @@ workload on reviewing.
 "Decision Making" Process
 -------------------------
 
-The following applies to code changes to the Bitcoin Core project (and related
+The following applies to code changes to the BitGold project (and related
 projects such as libsecp256k1), and is not to be confused with overall Bitcoin
 Network Protocol consensus changes.
 
-Whether a pull request is merged into Bitcoin Core rests with the project merge
+Whether a pull request is merged into BitGold rests with the project merge
 maintainers.
 
 Maintainers will take into consideration if a patch is in line with the general

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-See our website for versions of Bitcoin Core that are currently supported with
+See our website for versions of BitGold that are currently supported with
 security updates: https://bitcoincore.org/en/lifecycle/#schedule
 
 ## Reporting a Vulnerability

--- a/doc/build-freebsd.md
+++ b/doc/build-freebsd.md
@@ -16,7 +16,7 @@ pkg install boost-libs cmake git libevent pkgconf
 See [dependencies.md](dependencies.md) for a complete overview.
 
 ### 2. Clone Bitcoin Repo
-Now that `git` and all the required dependencies are installed, let's clone the Bitcoin Core repository to a directory. All build scripts and commands will run from this directory.
+Now that `git` and all the required dependencies are installed, let's clone the BitGold repository to a directory. All build scripts and commands will run from this directory.
 ```bash
 git clone https://github.com/bitcoin/bitcoin.git
 ```
@@ -37,7 +37,7 @@ pkg install sqlite3
 #### GUI Dependencies
 ###### Qt6
 
-Bitcoin Core includes a GUI built with the cross-platform Qt Framework. To compile the GUI, we need to install
+BitGold includes a GUI built with the cross-platform Qt Framework. To compile the GUI, we need to install
 the necessary parts of Qt, the libqrencode and pass `-DBUILD_GUI=ON`. Skip if you don't intend to use the GUI.
 
 ```bash
@@ -59,7 +59,7 @@ Otherwise, if you don't need QR encoding support, use the `-DWITH_QRENCODE=OFF` 
 #### Notifications
 ###### ZeroMQ
 
-Bitcoin Core can provide notifications via ZeroMQ. If the package is installed, support will be compiled in.
+BitGold can provide notifications via ZeroMQ. If the package is installed, support will be compiled in.
 ```bash
 pkg install libzmq4
 ```
@@ -73,11 +73,11 @@ pkg install python3 databases/py-sqlite3 net/py-pyzmq
 ```
 ---
 
-## Building Bitcoin Core
+## Building BitGold
 
 ### 1. Configuration
 
-There are many ways to configure Bitcoin Core, here are a few common examples:
+There are many ways to configure BitGold, here are a few common examples:
 
 ##### Descriptor Wallet and GUI:
 This enables the GUI, assuming `sqlite` and `qt` are installed.

--- a/doc/build-netbsd.md
+++ b/doc/build-netbsd.md
@@ -35,7 +35,7 @@ See [dependencies.md](dependencies.md) for a complete overview.
 
 ### 2. Clone Bitcoin Repo
 
-Clone the Bitcoin Core repository to a directory. All build scripts and commands will run from this directory.
+Clone the BitGold repository to a directory. All build scripts and commands will run from this directory.
 
 ```bash
 git clone https://github.com/bitcoin/bitcoin.git
@@ -58,7 +58,7 @@ pkgin install sqlite3
 #### GUI Dependencies
 ###### Qt6
 
-Bitcoin Core includes a GUI built with the cross-platform Qt Framework. To compile the GUI, we need to install
+BitGold includes a GUI built with the cross-platform Qt Framework. To compile the GUI, we need to install
 the necessary parts of Qt, the libqrencode and pass `-DBUILD_GUI=ON`. Skip if you don't intend to use the GUI.
 
 ```bash
@@ -78,7 +78,7 @@ Otherwise, if you don't need QR encoding support, use the `-DWITH_QRENCODE=OFF` 
 #### Notifications
 ###### ZeroMQ
 
-Bitcoin Core can provide notifications via ZeroMQ. If the package is installed, support will be compiled in.
+BitGold can provide notifications via ZeroMQ. If the package is installed, support will be compiled in.
 ```bash
 pkgin zeromq
 ```
@@ -92,11 +92,11 @@ To run the test suite (recommended), you will need to have Python 3 installed:
 pkgin install python310 py310-zmq
 ```
 
-## Building Bitcoin Core
+## Building BitGold
 
 ### 1. Configuration
 
-There are many ways to configure Bitcoin Core. Here is an example that
+There are many ways to configure BitGold. Here is an example that
 explicitly disables the wallet and GUI:
 
 ```bash

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -16,7 +16,7 @@ pkg_add git cmake boost libevent
 See [dependencies.md](dependencies.md) for a complete overview.
 
 ### 2. Clone Bitcoin Repo
-Clone the Bitcoin Core repository to a directory. All build scripts and commands will run from this directory.
+Clone the BitGold repository to a directory. All build scripts and commands will run from this directory.
 ``` bash
 git clone https://github.com/bitcoin/bitcoin.git
 ```
@@ -36,7 +36,7 @@ pkg_add sqlite3
 #### GUI Dependencies
 ###### Qt6
 
-Bitcoin Core includes a GUI built with the cross-platform Qt Framework. To compile the GUI, we need to install
+BitGold includes a GUI built with the cross-platform Qt Framework. To compile the GUI, we need to install
 the necessary parts of Qt, the libqrencode and pass `-DBUILD_GUI=ON`. Skip if you don't intend to use the GUI.
 
 ```bash
@@ -58,7 +58,7 @@ Otherwise, if you don't need QR encoding support, use the `-DWITH_QRENCODE=OFF` 
 #### Notifications
 ###### ZeroMQ
 
-Bitcoin Core can provide notifications via ZeroMQ. If the package is installed, support will be compiled in.
+BitGold can provide notifications via ZeroMQ. If the package is installed, support will be compiled in.
 ```bash
 pkg_add zeromq
 ```
@@ -71,11 +71,11 @@ To run the test suite (recommended), you will need to have Python 3 installed:
 pkg_add python py3-zmq  # Select the newest version of the python package if necessary.
 ```
 
-## Building Bitcoin Core
+## Building BitGold
 
 ### 1. Configuration
 
-There are many ways to configure Bitcoin Core, here are a few common examples:
+There are many ways to configure BitGold, here are a few common examples:
 
 ##### Descriptor Wallet and GUI:
 This enables descriptor wallet support and the GUI, assuming SQLite and Qt 6 are installed.

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -16,7 +16,7 @@ macOS comes with a built-in Terminal located in:
 ### 1. Xcode Command Line Tools
 
 The Xcode Command Line Tools are a collection of build tools for macOS.
-These tools must be installed in order to build Bitcoin Core from source.
+These tools must be installed in order to build BitGold from source.
 
 To install, run the following command from your terminal:
 
@@ -54,7 +54,7 @@ brew install cmake boost pkgconf libevent
 ### 4. Clone Bitcoin repository
 
 `git` should already be installed by default on your system.
-Now that all the required dependencies are installed, let's clone the Bitcoin Core repository to a directory.
+Now that all the required dependencies are installed, let's clone the BitGold repository to a directory.
 All build scripts and commands will run from this directory.
 
 ``` bash
@@ -80,7 +80,7 @@ install anything.
 
 ###### Qt
 
-Bitcoin Core includes a GUI built with the cross-platform Qt Framework. To compile the GUI, we need to install
+BitGold includes a GUI built with the cross-platform Qt Framework. To compile the GUI, we need to install
 Qt, libqrencode and pass `-DBUILD_GUI=ON`. Skip if you don't intend to use the GUI.
 
 ``` bash
@@ -143,14 +143,14 @@ brew install python
 
 #### Deploy Dependencies
 
-You can [deploy](#3-deploy-optional) a `.zip` containing the Bitcoin Core application.
+You can [deploy](#3-deploy-optional) a `.zip` containing the BitGold application.
 It is required that you have `python` and `zip` installed.
 
-## Building Bitcoin Core
+## Building BitGold
 
 ### 1. Configuration
 
-There are many ways to configure Bitcoin Core, here are a few common examples:
+There are many ways to configure BitGold, here are a few common examples:
 
 ##### Wallet (only SQlite) and GUI Support:
 
@@ -179,7 +179,7 @@ cmake -B build -LH
 ### 2. Compile
 
 After configuration, you are ready to compile.
-Run the following in your terminal to compile Bitcoin Core:
+Run the following in your terminal to compile BitGold:
 
 ``` bash
 cmake --build build     # Append "-j N" here for N parallel jobs.
@@ -194,9 +194,9 @@ You can also create a  `.zip` containing the `.app` bundle by running the follow
 cmake --build build --target deploy
 ```
 
-## Running Bitcoin Core
+## Running BitGold
 
-Bitcoin Core should now be available at `./build/bin/bitcoind`.
+BitGold should now be available at `./build/bin/bitcoind`.
 If you compiled support for the GUI, it should be available at `./build/bin/bitcoin-qt`.
 
 There is also a multifunction command line interface at `./build/bin/bitcoin`

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -1,6 +1,6 @@
 UNIX BUILD NOTES
 ====================
-Some notes on how to build Bitcoin Core in Unix.
+Some notes on how to build BitGold in Unix.
 
 (For BSD specific instructions, see `build-*bsd.md` in this directory.)
 
@@ -20,7 +20,7 @@ distributions](#linux-distribution-specific-instructions), or the
 ## Memory Requirements
 
 C++ compilers are memory-hungry. It is recommended to have at least 1.5 GB of
-memory available when compiling Bitcoin Core. On systems with less, gcc can be
+memory available when compiling BitGold. On systems with less, gcc can be
 tuned to conserve memory with additional `CMAKE_CXX_FLAGS`:
 
 
@@ -54,7 +54,7 @@ SQLite is required for the descriptor wallet:
 
     sudo apt install libsqlite3-dev
 
-To build Bitcoin Core without wallet, see [*Disable-wallet mode*](#disable-wallet-mode)
+To build BitGold without wallet, see [*Disable-wallet mode*](#disable-wallet-mode)
 
 ZMQ-enabled binaries are compiled with `-DWITH_ZMQ=ON` and require the following dependency:
 
@@ -71,7 +71,7 @@ Skip if you do not need IPC functionality.
 
 GUI dependencies:
 
-Bitcoin Core includes a GUI built with the cross-platform Qt Framework. To compile the GUI, we need to install
+BitGold includes a GUI built with the cross-platform Qt Framework. To compile the GUI, we need to install
 the necessary parts of Qt, the libqrencode and pass `-DBUILD_GUI=ON`. Skip if you don't intend to use the GUI.
 
     sudo apt-get install qt6-base-dev qt6-tools-dev qt6-l10n-tools qt6-tools-dev-tools libgl-dev
@@ -105,7 +105,7 @@ SQLite is required for the descriptor wallet:
 
     sudo dnf install sqlite-devel
 
-To build Bitcoin Core without wallet, see [*Disable-wallet mode*](#disable-wallet-mode)
+To build BitGold without wallet, see [*Disable-wallet mode*](#disable-wallet-mode)
 
 ZMQ-enabled binaries are compiled with `-DWITH_ZMQ=ON` and require the following dependency:
 
@@ -122,7 +122,7 @@ Skip if you do not need IPC functionality.
 
 GUI dependencies:
 
-Bitcoin Core includes a GUI built with the cross-platform Qt Framework. To compile the GUI, we need to install
+BitGold includes a GUI built with the cross-platform Qt Framework. To compile the GUI, we need to install
 the necessary parts of Qt, the libqrencode and pass `-DBUILD_GUI=ON`. Skip if you don't intend to use the GUI.
 
     sudo dnf install qt6-qtbase-devel qt6-qttools-devel
@@ -147,7 +147,7 @@ not use the packages of your Linux distribution.
 
 Disable-wallet mode
 --------------------
-When the intention is to only run a P2P node, without a wallet, Bitcoin Core can
+When the intention is to only run a P2P node, without a wallet, BitGold can
 be compiled in disable-wallet mode with:
 
     cmake -B build -DENABLE_WALLET=OFF

--- a/doc/build-windows-msvc.md
+++ b/doc/build-windows-msvc.md
@@ -23,7 +23,7 @@ Download and install [Git for Windows](https://git-scm.com/downloads/win). Once 
 
 ### 3. Clone Bitcoin Repository
 
-Clone the Bitcoin Core repository to a directory. All build scripts and commands will run from this directory.
+Clone the BitGold repository to a directory. All build scripts and commands will run from this directory.
 ```
 git clone https://github.com/bitcoin/bitcoin.git
 ```
@@ -31,11 +31,11 @@ git clone https://github.com/bitcoin/bitcoin.git
 
 ## Triplets and Presets
 
-The Bitcoin Core project supports the following vcpkg triplets:
+The BitGold project supports the following vcpkg triplets:
 - `x64-windows` (both CRT and library linkage is dynamic)
 - `x64-windows-static` (both CRT and library linkage is static)
 
-To facilitate build process, the Bitcoin Core project provides presets, which are used in this guide.
+To facilitate build process, the BitGold project provides presets, which are used in this guide.
 
 Available presets can be listed as follows:
 ```
@@ -69,7 +69,7 @@ ctest --test-dir build --build-config Release  # Append "-j N" for N parallel te
 
 ### 6. vcpkg-specific Issues and Workarounds
 
-vcpkg installation during the configuration step might fail for various reasons unrelated to Bitcoin Core.
+vcpkg installation during the configuration step might fail for various reasons unrelated to BitGold.
 
 If the failure is due to a "Buildtrees path … is too long" error, which is often encountered when building
 with `BUILD_GUI=ON` and using the default vcpkg installation provided by Visual Studio, you can
@@ -81,7 +81,7 @@ cmake -B build --preset vs2022-static -DVCPKG_INSTALL_OPTIONS="--x-buildtrees-ro
 ```
 
 If vcpkg installation fails with the message "Paths with embedded space may be handled incorrectly", which
-can occur if your local Bitcoin Core repository path contains spaces, you can override the vcpkg install directory
+can occur if your local BitGold repository path contains spaces, you can override the vcpkg install directory
 by setting the [`VCPKG_INSTALLED_DIR`](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/users/buildsystems/cmake-integration.md#vcpkg_installed_dir) variable:
 
 ```powershell

--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -1,9 +1,9 @@
 WINDOWS BUILD NOTES
 ====================
 
-Below are some notes on how to build Bitcoin Core for Windows.
+Below are some notes on how to build BitGold for Windows.
 
-The options known to work for building Bitcoin Core on Windows are:
+The options known to work for building BitGold on Windows are:
 
 * On Linux, using the [Mingw-w64](https://www.mingw-w64.org/) cross compiler tool chain.
 * On Windows, using [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/about) and Mingw-w64.
@@ -41,7 +41,7 @@ Acquire the source in the usual way:
     git clone https://github.com/bitcoin/bitcoin.git
     cd bitcoin
 
-Note that for WSL the Bitcoin Core source path MUST be somewhere in the default mount file system, for
+Note that for WSL the BitGold source path MUST be somewhere in the default mount file system, for
 example /usr/src/bitcoin, AND not under /mnt/d/. If this is not the case the dependency autoconf scripts will fail.
 This means you cannot use a directory that is located directly on the host Windows file system to perform the build.
 


### PR DESCRIPTION
## Summary
- rename CLIENT_NAME and CMake project to BitGold
- update build docs and top-level docs to refer to BitGold

## Testing
- `python3 test/lint/lint-files.py CMakeLists.txt doc/build-unix.md doc/build-freebsd.md doc/build-windows-msvc.md doc/build-netbsd.md doc/build-windows.md doc/build-openbsd.md doc/build-osx.md CONTRIBUTING.md SECURITY.md` *(fails: File contrib/stake_monitor.py contains a shebang line, but has the file permission 644 instead of the expected executable permission 755)*
- `python3 test/lint/lint-spelling.py CMakeLists.txt doc/build-unix.md doc/build-freebsd.md doc/build-windows-msvc.md doc/build-netbsd.md doc/build-windows.md doc/build-openbsd.md doc/build-osx.md CONTRIBUTING.md SECURITY.md` *(skipped: codespell not installed)*
- `python3 test/lint/check-doc.py` *(fails: Please add {'-staker'} to the hidden args in DummyWalletInit::AddWalletOptions)*

------
https://chatgpt.com/codex/tasks/task_b_689f2a9839b0832fab1fa86151846510