### PR TITLE
docs: summarize required build tools

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,1 +1,16 @@
-See [doc/build-\*.md](/doc)
+# Installation
+
+Bitcoin Core is built with CMake and a C++ compiler. A typical build requires:
+
+- C++ compiler such as GCC or Clang
+- [CMake](https://cmake.org/)
+- Build tool like [Ninja](https://ninja-build.org/) or [GNU Make](https://www.gnu.org/software/make/)
+
+## Build options
+
+| Build type | Description | CMake option |
+|------------|-------------|--------------|
+| GUI | Build the Qt-based `bitcoin-qt` graphical interface. | `-DBUILD_GUI=ON` |
+| Headless | Build command-line tools and daemon only. | `-DBUILD_GUI=OFF` |
+
+For detailed platform-specific instructions, see [doc/build-\*.md](doc).


### PR DESCRIPTION
## Summary
- outline required tools for building Bitcoin Core
- document GUI vs headless build options

## Testing
- `test/lint/check-doc.py INSTALL.md` *(fails: Please add {'-staker'} to hidden args in DummyWalletInit::AddWalletOptions)*

------
https://chatgpt.com/codex/tasks/task_b_689f2a9e7444832fa776c824055bb0c9