### PR TITLE
Enforce coinstake for first block

### DIFF
--- a/doc/staking.md
+++ b/doc/staking.md
@@ -2,7 +2,9 @@ BitGold Staker
 ==============
 
 BitGold combines proof-of-work with proof-of-stake. Any node that holds
-mature coins may stake to help secure the network and earn rewards.
+mature coins may stake to help secure the network and earn rewards. Every
+block after the genesis must include a coinstake transaction; there is no
+proof-of-work fallback for the first block.
 
 ## Enabling staking
 

--- a/src/pos/stake.cpp
+++ b/src/pos/stake.cpp
@@ -93,10 +93,7 @@ bool ContextualCheckProofOfStake(const CBlock& block, const CBlockIndex* pindexP
              "ContextualCheckProofOfStake: height=%d time=%u txs=%u",
              pindexPrev->nHeight, block.nTime, block.vtx.size());
 
-    // Allow first block after genesis to be mined with proof-of-work
-    if (pindexPrev->nHeight < 1) {
-        return true;
-    }
+    // All blocks after genesis must include a valid coinstake transaction
 
     if (block.vtx.size() < 2) {
         LogDebug(BCLog::STAKING,


### PR DESCRIPTION
## Summary
- require a coinstake transaction for blocks at height 1 and beyond
- document that there is no proof-of-work fallback for the first block

## Testing
- `ctest --test-dir build --output-on-failure` *(fails: interrupted after 3 tests due to environment constraints)*

------
https://chatgpt.com/codex/tasks/task_b_689f2e1cc6e4832fb3aa458c2a73e945