### PR TITLE
Add getstakinginfo RPC alias for stakerstatus

### DIFF
--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -875,6 +875,23 @@ static RPCHelpMan stakerstatus()
         }};
 }
 
+static RPCHelpMan getstakinginfo()
+{
+    return RPCHelpMan{
+        "getstakinginfo",
+        "Returns the staking status for this wallet.\n",
+        {},
+        RPCResult{
+            RPCResult::Type::OBJ, "", "", {
+                                              {RPCResult::Type::BOOL, "enabled", "true if staking is enabled via -staker"},
+                                              {RPCResult::Type::BOOL, "staking", "true if the staking thread is running"},
+                                          }},
+        RPCExamples{HelpExampleCli("getstakinginfo", "") + HelpExampleRpc("getstakinginfo", "")},
+        [](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
+            return stakerstatus().HandleRequest(request);
+        }};
+}
+
 // addresses
 RPCHelpMan getaddressinfo();
 RPCHelpMan getnewaddress();
@@ -1001,6 +1018,7 @@ std::span<const CRPCCommand> GetWalletRPCCommands()
         {"wallet", &walletpassphrasechange},
         {"wallet", &walletprocesspsbt},
         {"wallet", &stakerstatus},
+        {"wallet", &getstakinginfo},
     };
     return commands;
 }

--- a/test/functional/wallet_getstakinginfo.py
+++ b/test/functional/wallet_getstakinginfo.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test getstakinginfo RPC.
+
+Ensure getstakinginfo and stakerstatus return identical output.
+"""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+
+class GetStakingInfoTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    def run_test(self):
+        self.log.info("Compare stakerstatus and getstakinginfo outputs")
+        info_status = self.nodes[0].stakerstatus()
+        info_info = self.nodes[0].getstakinginfo()
+        assert_equal(info_status, info_info)
+
+
+if __name__ == '__main__':
+    GetStakingInfoTest(__file__).main()


### PR DESCRIPTION
## Summary
- add `getstakinginfo` wallet RPC that forwards to `stakerstatus`
- register `getstakinginfo` alongside `stakerstatus`
- add functional test ensuring both RPCs return identical output

## Testing
- `cmake -B build -S .`
- `cmake --build build -j4` *(fails: Interrupted)*
- `test/functional/test_runner.py wallet_getstakinginfo.py` *(fails: No functional tests to run. Re-compile with the -DBUILD_DAEMON=ON build option)*

------
https://chatgpt.com/codex/tasks/task_b_689f3e55d48c832fafc4a11d870fa0cc