### PR TITLE
Remove redundant HasValidProofOfWork function

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -121,14 +121,6 @@ static bool CheckProofOfWork(const uint256& hash, unsigned int nBits, const Cons
     return UintToArith256(hash) <= bnTarget;
 }
 
-bool HasValidProofOfWork(const std::vector<CBlockHeader>& headers, const Consensus::Params& params)
-{
-    for (const auto& header : headers) {
-        if (!CheckProofOfWork(header.GetHash(), header.nBits, params)) return false;
-    }
-    return true;
-}
-
 bool CheckBlock(const CBlock& block, BlockValidationState& state, const Consensus::Params& params, bool fCheckPOW, bool fCheckMerkleRoot)
 {
     // Check block weight


### PR DESCRIPTION
## Summary
- delete early HasValidProofOfWork definition in validation.cpp to avoid duplicate
- rely on comprehensive HasValidProofOfWork implementation

## Testing
- `ninja -C build src/CMakeFiles/bitcoin_node.dir/validation.cpp.o`
- `ninja -C build bitcoin_node`


------
https://chatgpt.com/codex/tasks/task_b_689f5060b114832f8663d61f1d3377db