### PR TITLE
Track and expose dividend pool balance

### DIFF
--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -116,6 +116,7 @@ static ChainstateLoadResult CompleteChainstateInitialization(
         // The on-disk coinsdb is now in a good state, create the cache
         chainstate->InitCoinsCache(chainman.m_total_coinstip_cache * init_cache_fraction);
         assert(chainstate->CanFlushToDisk());
+        chainstate->LoadDividendPool();
 
         if (!is_coinsview_empty(chainstate)) {
             // LoadChainTip initializes the chain based on CoinsTip()'s best block

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -168,7 +168,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock()
     coinbaseTx.vout[0].scriptPubKey = m_options.coinbase_output_script;
     CAmount validator_fee = nFees * 9 / 10;
     CAmount dividend_fee = nFees - validator_fee;
-    (void)dividend_fee; // TODO: distribute to dividend pool
+    m_chainstate.AddToDividendPool(dividend_fee);
     coinbaseTx.vout[0].nValue = validator_fee + GetBlockSubsidy(nHeight, chainparams.GetConsensus());
     // Dividend portion is currently unassigned; reserved for future distribution.
     coinbaseTx.vin[0].scriptSig = CScript() << nHeight << OP_0;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -472,6 +472,26 @@ static RPCHelpMan getdifficulty()
     };
 }
 
+static RPCHelpMan getdividendpool()
+{
+    return RPCHelpMan{
+        "getdividendpool",
+        "Returns the current dividend pool balance.\n",
+        {},
+        RPCResult{RPCResult::Type::NUM, "", "dividend pool balance in BTC"},
+        RPCExamples{
+            HelpExampleCli("getdividendpool", "") +
+            HelpExampleRpc("getdividendpool", "")
+        },
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
+            ChainstateManager& chainman = EnsureAnyChainman(request.context);
+            LOCK(cs_main);
+            CAmount pool = chainman.ActiveChainstate().GetDividendPool();
+            return ValueFromAmount(pool);
+        }
+    };
+}
+
 static RPCHelpMan getblockfrompeer()
 {
     return RPCHelpMan{
@@ -3435,6 +3455,7 @@ void RegisterBlockchainRPCCommands(CRPCTable& t)
         {"blockchain", &getblockheader},
         {"blockchain", &getchaintips},
         {"blockchain", &getdifficulty},
+        {"blockchain", &getdividendpool},
         {"blockchain", &getdeploymentinfo},
         {"blockchain", &gettxout},
         {"blockchain", &gettxoutsetinfo},

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -7,6 +7,7 @@
 
 #include <coins.h>
 #include <dbwrapper.h>
+#include <consensus/amount.h>
 #include <logging.h>
 #include <primitives/transaction.h>
 #include <random.h>
@@ -22,6 +23,7 @@
 static constexpr uint8_t DB_COIN{'C'};
 static constexpr uint8_t DB_BEST_BLOCK{'B'};
 static constexpr uint8_t DB_HEAD_BLOCKS{'H'};
+static constexpr uint8_t DB_DIVIDEND_POOL{'D'};
 // Keys used in previous version that might still be found in the DB:
 static constexpr uint8_t DB_COINS{'c'};
 
@@ -88,6 +90,18 @@ std::vector<uint256> CCoinsViewDB::GetHeadBlocks() const {
         return std::vector<uint256>();
     }
     return vhashHeadBlocks;
+}
+
+CAmount CCoinsViewDB::GetDividendPool() const
+{
+    CAmount pool{0};
+    m_db->Read(DB_DIVIDEND_POOL, pool);
+    return pool;
+}
+
+bool CCoinsViewDB::WriteDividendPool(CAmount amount)
+{
+    return m_db->Write(DB_DIVIDEND_POOL, amount);
 }
 
 bool CCoinsViewDB::BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &hashBlock) {

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -8,6 +8,7 @@
 
 #include <coins.h>
 #include <dbwrapper.h>
+#include <consensus/amount.h>
 #include <kernel/cs_main.h>
 #include <sync.h>
 #include <util/fs.h>
@@ -59,6 +60,10 @@ public:
 
     //! @returns filesystem path to on-disk storage or std::nullopt if in memory.
     std::optional<fs::path> StoragePath() { return m_db->StoragePath(); }
+
+    //! Read or update the dividend pool balance.
+    CAmount GetDividendPool() const;
+    bool WriteDividendPool(CAmount amount);
 };
 
 #endif // BITCOIN_TXDB_H

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2120,6 +2120,18 @@ void Chainstate::InitCoinsDB(
         CoinsViewOptions{});
 }
 
+void Chainstate::LoadDividendPool()
+{
+    m_dividend_pool = CoinsDB().GetDividendPool();
+}
+
+void Chainstate::AddToDividendPool(CAmount amount)
+{
+    m_dividend_pool += amount;
+    CoinsDB().WriteDividendPool(m_dividend_pool);
+    // TODO: Integrate quarterly payout distribution when available.
+}
+
 bool IsBlockMutated(const CBlock& block, bool check_witness_root)
 {
     bool mutated{false};

--- a/src/validation.h
+++ b/src/validation.h
@@ -607,6 +607,9 @@ public:
      */
     const std::optional<uint256> m_from_snapshot_blockhash;
 
+    //! Accumulated dividend fees awaiting distribution.
+    CAmount m_dividend_pool GUARDED_BY(::cs_main){0};
+
     /**
      * The base of the snapshot this chainstate was created from.
      *
@@ -637,6 +640,10 @@ public:
         AssertLockHeld(::cs_main);
         return Assert(m_coins_views)->m_dbview;
     }
+
+    void LoadDividendPool() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    void AddToDividendPool(CAmount amount) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    CAmount GetDividendPool() const EXCLUSIVE_LOCKS_REQUIRED(::cs_main) { return m_dividend_pool; }
 
     //! @returns A pointer to the mempool.
     CTxMemPool* GetMempool()


### PR DESCRIPTION
## Summary
- accumulate dividend fees into a chainstate dividend pool
- persist and expose dividend pool through new getdividendpool RPC

## Testing
- `cmake .. -GNinja -DBUILD_BITCOIN_GUI=OFF` *(fails: Could not find a package configuration file provided by "Boost")*


------
https://chatgpt.com/codex/tasks/task_b_68bd8185f8ec832ab558e39654fc4b31