### PR TITLE
refactor: disable pow after height 1

### DIFF
--- a/src/validation.h
+++ b/src/validation.h
@@ -92,6 +92,8 @@ enum class SynchronizationState {
 /** Documentation for argument 'checklevel'. */
 extern const std::vector<std::string> CHECKLEVEL_DOC;
 
+extern ChainstateManager* g_chainman;
+
 CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams);
 
 bool FatalError(kernel::Notifications& notifications, BlockValidationState& state, const bilingual_str& message);


### PR DESCRIPTION
## Summary
- reject proof-of-work blocks above height 1
- forward previous block index to ContextualCheckProofOfStake
- add unit test to ensure PoW blocks past height 1 are invalid

## Testing
- `cmake -S . -B build` *(fails: Could not find Boost configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68bd818aefb8832ab4f2e7e4305f27a4