### PR TITLE
Add bulletproofs scaffolding

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,22 @@ include(AddWindowsResources)
 configure_file(${PROJECT_SOURCE_DIR}/cmake/bitcoin-build-config.h.in bitcoin-build-config.h USE_SOURCE_PERMISSIONS @ONLY)
 include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 
+option(ENABLE_BULLETPROOFS "Enable Bulletproofs support" OFF)
+if(ENABLE_BULLETPROOFS)
+  find_package(PkgConfig)
+  if(PkgConfig_FOUND)
+    pkg_check_modules(SECP256K1_ZKP libsecp256k1_zkp)
+    if(SECP256K1_ZKP_FOUND)
+      add_library(bulletproofs INTERFACE)
+      target_include_directories(bulletproofs INTERFACE ${SECP256K1_ZKP_INCLUDE_DIRS})
+      target_link_libraries(bulletproofs INTERFACE ${SECP256K1_ZKP_LIBRARIES})
+      add_compile_definitions(ENABLE_BULLETPROOFS)
+    else()
+      message(WARNING "libsecp256k1_zkp not found, Bulletproofs disabled")
+    endif()
+  endif()
+endif()
+
 #=============================
 # Subprojects
 #=============================
@@ -332,6 +348,9 @@ target_link_libraries(bitcoin_node
     $<TARGET_NAME_IF_EXISTS:libevent::pthreads>
     $<TARGET_NAME_IF_EXISTS:USDT::headers>
 )
+if(TARGET bulletproofs)
+  target_link_libraries(bitcoin_node PRIVATE bulletproofs)
+endif()
 
 # Bitcoin wrapper executable that can call other executables.
 if(BUILD_BITCOIN_BIN)

--- a/src/bulletproofs.h
+++ b/src/bulletproofs.h
@@ -1,0 +1,21 @@
+#ifndef BITCOIN_BULLETPROOFS_H
+#define BITCOIN_BULLETPROOFS_H
+
+#include <vector>
+
+struct CBulletproof {
+    std::vector<unsigned char> proof;
+};
+
+inline bool VerifyBulletproof(const CBulletproof& proof)
+{
+#ifdef ENABLE_BULLETPROOFS
+    (void)proof; // TODO: call into libsecp256k1-zkp verification
+    return true;
+#else
+    (void)proof;
+    return false;
+#endif
+}
+
+#endif // BITCOIN_BULLETPROOFS_H

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -209,6 +209,9 @@ enum opcodetype
     // Opcode added by BIP 342 (Tapscript)
     OP_CHECKSIGADD = 0xba,
 
+    // Placeholder opcode to carry Bulletproof proofs
+    OP_BULLETPROOF = 0xbb,
+
     OP_INVALIDOPCODE = 0xff,
 };
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -65,6 +65,10 @@
 #include <util/translation.h>
 #include <validationinterface.h>
 
+#ifdef ENABLE_BULLETPROOFS
+#include <bulletproofs.h>
+#endif
+
 #include <algorithm>
 #include <cassert>
 #include <chrono>
@@ -489,6 +493,12 @@ static bool CheckInputsFromMempoolAndCache(const CTransaction& tx, TxValidationS
     }
 
     // Call CheckInputScripts() to cache signature and script validity against current tip consensus rules.
+#ifdef ENABLE_BULLETPROOFS
+    // Placeholder: validate any Bulletproof data attached to the transaction
+    if (!VerifyBulletproof(CBulletproof{})) {
+        return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-bulletproof");
+    }
+#endif
     return CheckInputScripts(tx, state, view, flags, /* cacheSigStore= */ true, /* cacheFullScriptStore= */ true, txdata, validation_cache);
 }
 

--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -46,3 +46,6 @@ target_link_libraries(bitcoin_wallet
     Boost::headers
     $<TARGET_NAME_IF_EXISTS:USDT::headers>
 )
+if(TARGET bulletproofs)
+  target_link_libraries(bitcoin_wallet PRIVATE bulletproofs)
+endif()

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5,6 +5,10 @@
 
 #include <wallet/wallet.h>
 
+#ifdef ENABLE_BULLETPROOFS
+#include <bulletproofs.h>
+#endif
+
 #include <addresstype.h>
 #include <bitcoin-build-config.h> // IWYU pragma: keep
 #include <blockfilter.h>
@@ -4464,4 +4468,19 @@ std::optional<WalletTXO> CWallet::GetTXO(const COutPoint& outpoint) const
     }
     return it->second;
 }
+#ifdef ENABLE_BULLETPROOFS
+bool CreateBulletproofProof(CWallet& wallet, const CTransaction& tx, CBulletproof& proof)
+{
+    (void)wallet;
+    (void)tx;
+    proof.proof.clear();
+    return true;
+}
+
+bool VerifyBulletproofProof(const CTransaction& tx, const CBulletproof& proof)
+{
+    (void)tx;
+    return VerifyBulletproof(proof);
+}
+#endif
 } // namespace wallet

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -36,6 +36,10 @@
 #include <wallet/types.h>
 #include <wallet/walletutil.h>
 
+#ifdef ENABLE_BULLETPROOFS
+#include <bulletproofs.h>
+#endif
+
 #include <atomic>
 #include <cassert>
 #include <cstddef>
@@ -1166,6 +1170,11 @@ struct MigrationResult {
 [[nodiscard]] util::Result<MigrationResult> MigrateLegacyToDescriptor(const std::string& wallet_name, const SecureString& passphrase, WalletContext& context);
 //! Requirement: The wallet provided to this function must be isolated, with no attachment to the node's context.
 [[nodiscard]] util::Result<MigrationResult> MigrateLegacyToDescriptor(std::shared_ptr<CWallet> local_wallet, const SecureString& passphrase, WalletContext& context);
+
+#ifdef ENABLE_BULLETPROOFS
+bool CreateBulletproofProof(CWallet& wallet, const CTransaction& tx, CBulletproof& proof);
+bool VerifyBulletproofProof(const CTransaction& tx, const CBulletproof& proof);
+#endif
 } // namespace wallet
 
 #endif // BITCOIN_WALLET_WALLET_H


### PR DESCRIPTION
## Summary
- add optional Bulletproofs build option and link to node and wallet
- define placeholder OP_BULLETPROOF script opcode
- stub consensus and wallet hooks for Bulletproof proof verification

## Testing
- `cmake -S . -B build -GNinja -DBUILD_BITCOIN_QT=OFF` *(fails: Could not find a package configuration file provided by "Boost" (requested version 1.73.0))*

------
https://chatgpt.com/codex/tasks/task_b_68bd8194495c832a81b650161fa85fd9