### PR TITLE
Add PoS unit and functional tests

### DIFF
--- a/doc/pos_test_guide.md
+++ b/doc/pos_test_guide.md
@@ -1,0 +1,40 @@
+# Proof-of-Stake Testing Guide
+
+This guide describes the proof-of-stake tests added to the tree and the
+expected outcomes when they run successfully.
+
+## Unit tests
+
+The stake unit tests live in `src/test/stake_tests.cpp` and exercise three
+core concepts:
+
+- **Stake kernel hashing** – verifies the kernel hash calculation matches a
+  deterministic expectation.
+- **Stake modifier** – ensures different stake inputs yield distinct kernels.
+- **Block validation** – confirms blocks fail when the stake input is below the
+  minimum amount.
+
+Run the tests with:
+
+```bash
+src/test/test_bitcoin --run_test=stake_tests
+```
+
+## Functional tests
+
+Three functional tests cover higher level staking behaviour:
+
+- `pos_block_staking.py` stakes a block using wallet funds.
+- `pos_reorg.py` demonstrates a reorganisation when competing stake chains
+  meet, with the longer chain winning.
+- `pos_slashing.py` builds the slashing tracker and detects a double-sign
+  attempt.
+
+Execute an individual test via:
+
+```bash
+test/functional/pos_block_staking.py
+```
+
+Each script should exit without errors when the expected behaviour is
+observed.

--- a/src/test/stake_tests.cpp
+++ b/src/test/stake_tests.cpp
@@ -3,6 +3,7 @@
 #include <consensus/amount.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
+#include <hash.h>
 #include <script/script.h>
 #include <validation.h>
 #include <test/util/setup_common.h>
@@ -75,6 +76,68 @@ BOOST_AUTO_TEST_CASE(invalid_kernel_target)
                                       amount, prevout, nTimeTx, hash_proof, false));
 }
 
+BOOST_AUTO_TEST_CASE(kernel_hash_matches_expectation)
+{
+    uint256 prev_hash{1};
+    CBlockIndex prev_index;
+    prev_index.nHeight = 1;
+    prev_index.nTime = 100;
+    prev_index.phashBlock = &prev_hash;
+
+    uint256 hash_block_from{2};
+    unsigned int nTimeBlockFrom = 0;
+    CAmount amount = 100 * COIN;
+    COutPoint prevout{Txid::FromUint256(uint256{3}), 0};
+
+    unsigned int nBits = 0x207fffff;
+    unsigned int nTimeTx = MIN_STAKE_AGE;
+
+    uint256 expected_modifier;
+    {
+        HashWriter ss_mod;
+        ss_mod << prev_index.GetBlockHash() << prevout.hash << prevout.n;
+        expected_modifier = ss_mod.GetHash();
+    }
+
+    uint256 expected_hash;
+    {
+        HashWriter ss_kernel;
+        ss_kernel << expected_modifier << nTimeBlockFrom << prevout.hash << prevout.n
+                  << nTimeTx;
+        expected_hash = ss_kernel.GetHash();
+    }
+
+    uint256 hash_proof;
+    BOOST_CHECK(CheckStakeKernelHash(&prev_index, nBits, hash_block_from, nTimeBlockFrom,
+                                     amount, prevout, nTimeTx, hash_proof, false));
+    BOOST_CHECK_EQUAL(hash_proof, expected_hash);
+}
+
+BOOST_AUTO_TEST_CASE(stake_modifier_differs_per_input)
+{
+    uint256 prev_hash{1};
+    CBlockIndex prev_index;
+    prev_index.nHeight = 1;
+    prev_index.nTime = 100;
+    prev_index.phashBlock = &prev_hash;
+
+    uint256 hash_block_from{2};
+    unsigned int nTimeBlockFrom = 0;
+    unsigned int nBits = 0x207fffff;
+    unsigned int nTimeTx = MIN_STAKE_AGE;
+
+    COutPoint prevout1{Txid::FromUint256(uint256{3}), 0};
+    COutPoint prevout2{Txid::FromUint256(uint256{4}), 1};
+
+    uint256 proof1;
+    BOOST_CHECK(CheckStakeKernelHash(&prev_index, nBits, hash_block_from, nTimeBlockFrom,
+                                     100 * COIN, prevout1, nTimeTx, proof1, false));
+    uint256 proof2;
+    BOOST_CHECK(CheckStakeKernelHash(&prev_index, nBits, hash_block_from, nTimeBlockFrom,
+                                     100 * COIN, prevout2, nTimeTx, proof2, false));
+    BOOST_CHECK(proof1 != proof2);
+}
+
 BOOST_AUTO_TEST_CASE(height1_requires_coinstake)
 {
     uint256 prev_hash{1};
@@ -145,6 +208,50 @@ BOOST_AUTO_TEST_CASE(valid_height1_coinstake)
 
     Consensus::Params params;
     BOOST_CHECK(ContextualCheckProofOfStake(block, &prev_index, view, chain, params));
+}
+
+BOOST_AUTO_TEST_CASE(reject_low_stake_amount)
+{
+    uint256 prev_hash{1};
+    CBlockIndex prev_index;
+    prev_index.nHeight = 0;
+    prev_index.nTime = 0;
+    prev_index.nBits = 0x207fffff;
+    prev_index.phashBlock = &prev_hash;
+
+    CChain chain;
+    chain.SetTip(prev_index);
+
+    CCoinsView view_base;
+    CCoinsViewCache view(&view_base);
+
+    COutPoint prevout{Txid::FromUint256(uint256{2}), 0};
+    Coin coin;
+    coin.out.nValue = COIN / 2; // below minimum stake amount
+    coin.nHeight = 0;
+    view.AddCoin(prevout, std::move(coin), false);
+
+    CBlock block;
+    block.nTime = MIN_STAKE_AGE + 16;
+    block.nBits = 0x207fffff;
+
+    CMutableTransaction coinbase;
+    coinbase.vin.resize(1);
+    coinbase.vin[0].prevout.SetNull();
+    coinbase.vout.resize(1);
+    block.vtx.emplace_back(MakeTransactionRef(coinbase));
+
+    CMutableTransaction coinstake;
+    coinstake.nLockTime = 1;
+    coinstake.vin.emplace_back(prevout);
+    coinstake.vin[0].nSequence = CTxIn::SEQUENCE_FINAL;
+    coinstake.vout.resize(2);
+    coinstake.vout[0].SetNull();
+    coinstake.vout[1].nValue = COIN / 2;
+    block.vtx.emplace_back(MakeTransactionRef(std::move(coinstake)));
+
+    Consensus::Params params;
+    BOOST_CHECK(!ContextualCheckProofOfStake(block, &prev_index, view, chain, params));
 }
 
 BOOST_AUTO_TEST_CASE(height1_allows_young_coinstake)

--- a/test/functional/pos_block_staking.py
+++ b/test/functional/pos_block_staking.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Stake a single block using a wallet UTXO."""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.blocktools import create_block, create_coinbase
+from test_framework.messages import (
+    CTransaction,
+    CTxIn,
+    CTxOut,
+    COutPoint,
+    COIN,
+    hash256,
+    uint256_from_compact,
+)
+from test_framework.script import CScript
+from test_framework.util import assert_equal
+
+STAKE_TIMESTAMP_MASK = 0xF
+MIN_STAKE_AGE = 60 * 60
+
+
+def check_kernel(prev_hash, prev_height, prev_time, nbits, stake_hash, stake_time, amount, prevout, ntime):
+    if ntime & STAKE_TIMESTAMP_MASK:
+        return False
+    if ntime <= stake_time or ntime - stake_time < MIN_STAKE_AGE:
+        return False
+    stake_modifier = hash256(
+        bytes.fromhex(prev_hash)[::-1]
+        + prev_height.to_bytes(4, "little")
+        + prev_time.to_bytes(4, "little")
+    )
+    ntime_masked = ntime & ~STAKE_TIMESTAMP_MASK
+    stake_time_masked = stake_time & ~STAKE_TIMESTAMP_MASK
+    data = (
+        stake_modifier
+        + bytes.fromhex(stake_hash)[::-1]
+        + stake_time_masked.to_bytes(4, "little")
+        + bytes.fromhex(prevout["txid"])[::-1]
+        + prevout["vout"].to_bytes(4, "little")
+        + ntime_masked.to_bytes(4, "little")
+    )
+    proof = hash256(data)
+    target = uint256_from_compact(nbits) * (amount // COIN)
+    return int.from_bytes(proof[::-1], "big") <= target
+
+
+class PosBlockStakingTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    def run_test(self):
+        node = self.nodes[0]
+        addr = node.getnewaddress()
+        node.generatetoaddress(150, addr)
+
+        unspent = node.listunspent()[0]
+        txid = unspent["txid"]
+        vout = unspent["vout"]
+        amount = int(unspent["amount"] * COIN)
+        prevout = {"txid": txid, "vout": vout}
+
+        prev_height = node.getblockcount()
+        prev_hash = node.getbestblockhash()
+        prev_block = node.getblock(prev_hash)
+        nbits = int(prev_block["bits"], 16)
+        prev_time = prev_block["time"]
+
+        stake_block_hash = node.gettransaction(txid)["blockhash"]
+        stake_time = node.getblock(stake_block_hash)["time"]
+
+        ntime = prev_time + 16
+        while not check_kernel(
+            prev_hash,
+            prev_height,
+            prev_time,
+            nbits,
+            stake_block_hash,
+            stake_time,
+            amount,
+            prevout,
+            ntime,
+        ):
+            ntime += 16
+
+        script = CScript(bytes.fromhex(unspent["scriptPubKey"]))
+        coinstake = CTransaction()
+        coinstake.nLockTime = prev_height + 1
+        coinstake.vin.append(CTxIn(COutPoint(int(txid, 16), vout)))
+        coinstake.vout.append(CTxOut(0, CScript()))
+        reward = 50 * COIN
+        coinstake.vout.append(CTxOut(amount + reward, script))
+        signed_hex = node.signrawtransactionwithwallet(coinstake.serialize().hex())["hex"]
+        coinstake = CTransaction()
+        coinstake.deserialize(bytes.fromhex(signed_hex))
+
+        coinbase = create_coinbase(prev_height + 1, nValue=0)
+        block = create_block(
+            int(prev_hash, 16),
+            coinbase,
+            ntime,
+            tmpl={"bits": prev_block["bits"], "height": prev_height + 1},
+            txlist=[coinstake],
+        )
+        block.hashMerkleRoot = block.calc_merkle_root()
+        node.submitblock(block.serialize().hex())
+        assert_equal(node.getblockcount(), prev_height + 1)
+
+
+if __name__ == "__main__":
+    PosBlockStakingTest(__file__).main()

--- a/test/functional/pos_reorg.py
+++ b/test/functional/pos_reorg.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Test proof-of-stake reorg behavior."""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.blocktools import create_block, create_coinbase
+from test_framework.messages import (
+    CTransaction,
+    CTxIn,
+    CTxOut,
+    COutPoint,
+    COIN,
+    hash256,
+    uint256_from_compact,
+)
+from test_framework.script import CScript
+from test_framework.util import assert_equal
+
+STAKE_TIMESTAMP_MASK = 0xF
+MIN_STAKE_AGE = 60 * 60
+
+
+def check_kernel(prev_hash, prev_height, prev_time, nbits, stake_hash, stake_time, amount, prevout, ntime):
+    if ntime & STAKE_TIMESTAMP_MASK:
+        return False
+    if ntime <= stake_time or ntime - stake_time < MIN_STAKE_AGE:
+        return False
+    stake_modifier = hash256(
+        bytes.fromhex(prev_hash)[::-1]
+        + prev_height.to_bytes(4, "little")
+        + prev_time.to_bytes(4, "little")
+    )
+    ntime_masked = ntime & ~STAKE_TIMESTAMP_MASK
+    stake_time_masked = stake_time & ~STAKE_TIMESTAMP_MASK
+    data = (
+        stake_modifier
+        + bytes.fromhex(stake_hash)[::-1]
+        + stake_time_masked.to_bytes(4, "little")
+        + bytes.fromhex(prevout["txid"])[::-1]
+        + prevout["vout"].to_bytes(4, "little")
+        + ntime_masked.to_bytes(4, "little")
+    )
+    proof = hash256(data)
+    target = uint256_from_compact(nbits) * (amount // COIN)
+    return int.from_bytes(proof[::-1], "big") <= target
+
+
+def stake_block(node):
+    unspent = node.listunspent()[0]
+    txid = unspent["txid"]
+    vout = unspent["vout"]
+    amount = int(unspent["amount"] * COIN)
+    prevout = {"txid": txid, "vout": vout}
+
+    prev_height = node.getblockcount()
+    prev_hash = node.getbestblockhash()
+    prev_block = node.getblock(prev_hash)
+    nbits = int(prev_block["bits"], 16)
+    prev_time = prev_block["time"]
+
+    stake_block_hash = node.gettransaction(txid)["blockhash"]
+    stake_time = node.getblock(stake_block_hash)["time"]
+
+    ntime = prev_time + 16
+    while not check_kernel(
+        prev_hash,
+        prev_height,
+        prev_time,
+        nbits,
+        stake_block_hash,
+        stake_time,
+        amount,
+        prevout,
+        ntime,
+    ):
+        ntime += 16
+
+    script = CScript(bytes.fromhex(unspent["scriptPubKey"]))
+    coinstake = CTransaction()
+    coinstake.nLockTime = prev_height + 1
+    coinstake.vin.append(CTxIn(COutPoint(int(txid, 16), vout)))
+    coinstake.vout.append(CTxOut(0, CScript()))
+    reward = 50 * COIN
+    coinstake.vout.append(CTxOut(amount + reward, script))
+    signed_hex = node.signrawtransactionwithwallet(coinstake.serialize().hex())["hex"]
+    coinstake = CTransaction()
+    coinstake.deserialize(bytes.fromhex(signed_hex))
+
+    coinbase = create_coinbase(prev_height + 1, nValue=0)
+    block = create_block(
+        int(prev_hash, 16),
+        coinbase,
+        ntime,
+        tmpl={"bits": prev_block["bits"], "height": prev_height + 1},
+        txlist=[coinstake],
+    )
+    block.hashMerkleRoot = block.calc_merkle_root()
+    node.submitblock(block.serialize().hex())
+    assert_equal(node.getblockcount(), prev_height + 1)
+
+
+class PosReorgTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+
+    def setup_network(self):
+        self.setup_nodes()
+        self.connect_nodes(0, 1)
+
+    def run_test(self):
+        node0, node1 = self.nodes
+        addr0 = node0.getnewaddress()
+        node0.generatetoaddress(150, addr0)
+        self.sync_all()
+        start_height = node0.getblockcount()
+
+        # Give node1 access to staking funds
+        node1.importprivkey(node0.dumpprivkey(addr0))
+
+        self.disconnect_nodes(0, 1)
+
+        stake_block(node0)
+        stake_block(node1)
+        stake_block(node1)
+
+        self.connect_nodes(0, 1)
+        self.sync_blocks()
+        expected_height = start_height + 2
+        assert_equal(node0.getblockcount(), expected_height)
+        assert_equal(node1.getblockcount(), expected_height)
+        assert_equal(node0.getbestblockhash(), node1.getbestblockhash())
+
+
+if __name__ == "__main__":
+    PosReorgTest(__file__).main()

--- a/test/functional/pos_slashing.py
+++ b/test/functional/pos_slashing.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Exercise the slashing tracker to detect double-signing."""
+
+import ctypes
+import subprocess
+from pathlib import Path
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+
+class PosSlashingTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 0
+
+    def run_test(self):
+        repo_root = Path(__file__).resolve().parents[2]
+        workdir = Path(self.options.tmpdir)
+        wrapper = workdir / "slashing_wrap.cpp"
+        sofile = workdir / "libslashing.so"
+        wrapper.write_text(
+            '#include "pos/slashing.h"\n'
+            "extern \"C\" {\n"
+            "pos::SlashingTracker* slashing_create(){return new pos::SlashingTracker();}\n"
+            "void slashing_destroy(pos::SlashingTracker* t){delete t;}\n"
+            "bool slashing_detect(pos::SlashingTracker* t,const char* v){return t->DetectDoubleSign(std::string{v});}\n"
+            "}\n"
+        )
+        subprocess.check_call(
+            [
+                "g++",
+                "-std=c++17",
+                "-shared",
+                "-fPIC",
+                str(repo_root / "src/pos/slashing.cpp"),
+                str(wrapper),
+                "-I" + str(repo_root / "src"),
+                "-o",
+                str(sofile),
+            ]
+        )
+        lib = ctypes.CDLL(str(sofile))
+        lib.slashing_create.restype = ctypes.c_void_p
+        lib.slashing_detect.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+        lib.slashing_detect.restype = ctypes.c_bool
+        lib.slashing_destroy.argtypes = [ctypes.c_void_p]
+        tracker = lib.slashing_create()
+        assert_equal(lib.slashing_detect(tracker, b"validator"), False)
+        assert_equal(lib.slashing_detect(tracker, b"validator"), True)
+        lib.slashing_destroy(tracker)
+
+
+if __name__ == "__main__":
+    PosSlashingTest(__file__).main()


### PR DESCRIPTION
## Summary
- Expand stake unit tests for kernel hashing, modifier derivation, and low-value rejection
- Add functional tests for staking a block, PoS chain reorg, and slashing detection
- Document PoS test scenarios and expected results

## Testing
- `cmake -S . -B build -GNinja` (passes)
- `ninja -C build test_bitcoin bitcoind bitcoin-cli` *(fails: build interrupted by user)*


------
https://chatgpt.com/codex/tasks/task_b_68bd8c4684bc832a85174089ca84fb3b