### PR TITLE
doc: add PoS 3.1 overview and examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,11 @@ Before you start contributing, familiarize yourself with the BitGold build
 system and tests. Refer to the documentation in the repository on how to build
 BitGold and how to run the unit tests, functional tests, and fuzz tests.
 
+Developers working on staking or other PoS features should review
+[doc/pos3.1-overview.md](doc/pos3.1-overview.md) to understand the current
+consensus rules and deployment details. Example configuration files live under
+`doc/examples/` and should be kept in sync with any behavior changes.
+
 There are many open issues of varying difficulty waiting to be fixed.
 If you're looking for somewhere to start contributing, check out the
 [good first issue](https://github.com/bitcoin/bitcoin/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ validate blocks and transactions. The protocol targets 8-minute block times and
 the block subsidy halves every 90 000 blocks. In addition to proof-of-work,
 BitGold implements proof-of-stake staking so holders can help secure the
 network. The software also includes a wallet and graphical user interface,
-which can be optionally built.
+which can be optionally built. The current release implements
+Proof-of-Stake 3.1, adding dynamic stake weighting and cold staking support.
+See [doc/pos3.1-overview.md](doc/pos3.1-overview.md) for an overview and
+deployment guidance.
 
 Further information about BitGold is available in the [doc folder](/doc).
 
@@ -38,7 +41,9 @@ Staking
 
 To participate in BitGold's proof-of-stake, run `bitgoldd` or `bitgold-qt` with
 `-staker`, or add `staker=1` to `bitgold.conf`. The staking status can be
-checked with `bitgold-cli stakerstatus`.
+checked with `bitgold-cli stakerstatus`. The staking engine uses the
+PoS 3.1 consensus rules described in
+[doc/pos3.1-overview.md](doc/pos3.1-overview.md).
 
 Testing
 -------

--- a/doc/examples/network.conf
+++ b/doc/examples/network.conf
@@ -1,0 +1,14 @@
+# Example network parameters for a PoS node
+
+# Connect to specific peers
+addnode=seed1.bitgold.org
+addnode=seed2.bitgold.org
+
+# Use the main network
+testnet=0
+
+# Limit maximum connections
+maxconnections=64
+
+# Enable listen for inbound connections
+listen=1

--- a/doc/examples/staking.conf
+++ b/doc/examples/staking.conf
@@ -1,0 +1,10 @@
+# Example staking configuration
+
+# Enable staking
+staking=1
+
+# Reserve a balance that will not be used for staking
+reservebalance=100
+
+# Limit the number of coinstake attempts per second
+stakethreadlimit=4

--- a/doc/pos3.1-overview.md
+++ b/doc/pos3.1-overview.md
@@ -1,0 +1,34 @@
+# Proof-of-Stake 3.1 Overview
+
+Proof-of-Stake (PoS) 3.1 refines BitGold's hybrid consensus by improving stake weighting
+and simplifying wallet configuration. Blocks may be created by miners or stakers and
+all participants are encouraged to keep their nodes online to maximise network security.
+
+## Highlights
+
+- Dynamic stake modifier refreshes periodically to resist grinding attacks.
+- Staking rewards scale with coin age up to a configurable maximum.
+- Cold staking lets a hot node stake using coins held in an offline wallet.
+
+## Deployment
+
+PoS 3.1 activates at the network height agreed by the community. Nodes should be
+upgraded prior to the activation block.
+
+1. Install the latest BitGold release.
+2. Review the configuration examples in `doc/examples/`.
+3. Restart the node with staking enabled:
+   
+   ```bash
+   bitgoldd -staking=1
+   ```
+4. Monitor the logs for `stake` messages to verify participation.
+
+Existing stakers do not need to re-create their wallets. The upgrade is
+backwards compatible and the node will continue operating after the
+activation block.
+
+## Further Reading
+
+- [Staking guide](staking.md)
+- [Network parameters](examples/network.conf)


### PR DESCRIPTION
## Summary
- document Proof-of-Stake 3.1 overview and deployment details
- mention PoS 3.1 in README and CONTRIBUTING developer notes
- add example staking and network configuration files

## Testing
- `python3 test/lint/check-doc.py`
- `python3 test/lint/lint-spelling.py doc/pos3.1-overview.md doc/examples/staking.conf doc/examples/network.conf README.md CONTRIBUTING.md`


------
https://chatgpt.com/codex/tasks/task_b_68bd8c482d00832a91a6fe655a247798