### PR TITLE
Implement PoSV3.1 staking rules

### DIFF
--- a/src/pos/stake.h
+++ b/src/pos/stake.h
@@ -10,10 +10,12 @@
 
 class CBlockIndex;
 
-// Timestamp granularity for staked blocks (64 seconds, PoSV3)
-static constexpr unsigned int STAKE_TIMESTAMP_MASK = 0x3F;
-// Minimum coin age for staking (8 hours, PoSV3)
-static constexpr int64_t MIN_STAKE_AGE = 60 * 60 * 8;
+// Timestamp granularity for staked blocks (16 seconds, PoSV3.1)
+static constexpr unsigned int STAKE_TIMESTAMP_MASK = 0xF;
+// Target spacing between staked blocks (16 seconds, PoSV3.1)
+static constexpr unsigned int STAKE_TARGET_SPACING = 16;
+// Minimum coin age for staking (1 hour, PoSV3.1)
+static constexpr int64_t MIN_STAKE_AGE = 60 * 60;
 
 /** Check that the kernel for a stake meets the required target */
 bool CheckStakeKernelHash(const CBlockIndex* pindexPrev, unsigned int nBits,


### PR DESCRIPTION
## Summary
- add PoSV3.1 staking constants for timestamp granularity, target spacing and coin age
- update stake kernel and contextual PoS checks for PoSV3.1 hash and slot rules
- validate coinstake format and invoke PoS checks during block validation

## Testing
- `cmake -B build -GNinja`
- `ninja -C build test_bitcoin` *(fails: build stopped, subcommand failed)*

------
https://chatgpt.com/codex/tasks/task_b_68bd8c42a0d4832aaabf5c3cf883c31c