### PR TITLE
Add TestBlockValidity compat wrapper

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -288,6 +288,7 @@ add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
   node/miner.cpp
   node/mini_miner.cpp
   node/minisketchwrapper.cpp
+  node/compat_wrappers.cpp
   node/peerman_args.cpp
   node/psbt.cpp
   node/timeoffsets.cpp

--- a/src/node/compat_wrappers.cpp
+++ b/src/node/compat_wrappers.cpp
@@ -1,0 +1,8 @@
+#include <validation.h>
+
+bool TestBlockValidity(Chainstate& chainstate, const CBlock& block, bool check_pow, bool check_merkle_root)
+{
+    BlockValidationState state;
+    return chainstate.TestBlockValidity(state, block, check_pow, check_merkle_root);
+}
+


### PR DESCRIPTION
## Summary
- add compat wrapper for TestBlockValidity
- compile compat wrappers into node library

## Testing
- `make -C build/src node/compat_wrappers.o` *(fails: ambiguating new declaration and missing Chainstate::TestBlockValidity)*

------
https://chatgpt.com/codex/tasks/task_b_68be2fc5af04832a85b60a43e9ce9240