### PR TITLE
Add ChainstateManager IBD wrapper

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -275,6 +275,7 @@ add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
   node/chainstatemanager_args.cpp
   node/coin.cpp
   node/coins_view_args.cpp
+  node/compat_wrappers.cpp
   node/connection_types.cpp
   node/context.cpp
   node/database_args.cpp

--- a/src/node/compat_wrappers.cpp
+++ b/src/node/compat_wrappers.cpp
@@ -1,0 +1,10 @@
+// Copyright (c) 2024 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <validation.h>
+
+bool ChainstateManager::IsInitialBlockDownload() const
+{
+    return const_cast<ChainstateManager*>(this)->ActiveChainstate().IsInitialBlockDownload();
+}


### PR DESCRIPTION
## Summary
- implement ChainstateManager::IsInitialBlockDownload using ActiveChainstate
- register compat_wrappers.cpp in build

## Testing
- `cmake -B build -G Ninja`
- `ninja -C build src/CMakeFiles/bitcoin_node.dir/node/compat_wrappers.cpp.o` *(fails: class Chainstate has no member named IsInitialBlockDownload)*

------
https://chatgpt.com/codex/tasks/task_b_68be2fc65534832abab43b6922f15288