### PR TITLE
Add ChainstateManager ProcessNewBlock wrapper

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -275,6 +275,7 @@ add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
   node/chainstatemanager_args.cpp
   node/coin.cpp
   node/coins_view_args.cpp
+  node/compat_wrappers.cpp
   node/connection_types.cpp
   node/context.cpp
   node/database_args.cpp

--- a/src/node/compat_wrappers.cpp
+++ b/src/node/compat_wrappers.cpp
@@ -1,0 +1,20 @@
+// Copyright (c) 2024 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <validation.h>
+#include <chain.h>
+#include <node/blockstorage.h>
+#include <memory>
+
+// Forward declaration of the upstream free function
+bool ProcessNewBlock(ChainstateManager& chainman, const std::shared_ptr<const CBlock>& block,
+                     bool force_processing, bool min_pow_checked, bool* new_block);
+
+bool ChainstateManager::ProcessNewBlock(const std::shared_ptr<const CBlock>& block,
+                                        bool force_processing,
+                                        bool min_pow_checked,
+                                        bool* new_block)
+{
+    return ::ProcessNewBlock(*this, block, force_processing, min_pow_checked, new_block);
+}


### PR DESCRIPTION
## Summary
- Add compat wrapper implementing `ChainstateManager::ProcessNewBlock` delegating to free `::ProcessNewBlock`
- Include new wrapper file in `bitcoin_node` build

## Testing
- `cmake -GNinja -B build`
- `ninja -C build bitcoin_node`


------
https://chatgpt.com/codex/tasks/task_b_68be2fc4eebc832ab93ba610b3ab3120