### PR TITLE
Add placeholder TestNet4 support and mempool info fixes

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -47,7 +47,7 @@ void ReadRegTestArgs(const ArgsManager& args, CChainParams::RegTestOptions& opti
     if (HasTestOption(args, "bip94")) options.enforce_bip94 = true;
 
     if (auto value = args.GetIntArg("-posactivationheight")) {
-        options.pos_activation_height = int{*value};
+        options.pos_activation_height = static_cast<int>(*value);
     }
 
     for (const std::string& arg : args.GetArgs("-testactivationheight")) {
@@ -124,7 +124,11 @@ std::unique_ptr<const CChainParams> CreateChainParams(const ArgsManager& args, c
         return CChainParams::Main();
     case ChainType::TESTNET:
         return CChainParams::TestNet();
-    
+
+    case ChainType::TESTNET4:
+        // TODO: Replace with dedicated TestNet4 parameters once available.
+        return CChainParams::TestNet();
+
     case ChainType::SIGNET: {
         auto opts = CChainParams::SigNetOptions{};
         ReadSigNetArgs(args, opts);

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -44,7 +44,12 @@ std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const ChainType chain)
         return std::make_unique<CBaseChainParams>("", 8332);
     case ChainType::TESTNET:
         return std::make_unique<CBaseChainParams>("testnet3", 18332);
-    
+
+    case ChainType::TESTNET4:
+        // The dedicated parameters for testnet4 are not yet defined.
+        // Use the placeholder network and RPC port for now.
+        return std::make_unique<CBaseChainParams>("testnet4", 48332);
+
     case ChainType::SIGNET:
         return std::make_unique<CBaseChainParams>("signet", 38332);
     case ChainType::REGTEST:

--- a/src/node/compat_wrappers.cpp
+++ b/src/node/compat_wrappers.cpp
@@ -1,8 +1,11 @@
 #include <validation.h>
 
+namespace node {
+
 bool TestBlockValidity(Chainstate& chainstate, const CBlock& block, bool check_pow, bool check_merkle_root)
 {
-    BlockValidationState state;
-    return chainstate.TestBlockValidity(state, block, check_pow, check_merkle_root);
+    const BlockValidationState state = ::TestBlockValidity(chainstate, block, check_pow, check_merkle_root);
+    return state.IsValid();
 }
 
+} // namespace node

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -412,7 +412,8 @@ private:
 
     static TxMempoolInfo GetInfo(CTxMemPool::indexed_transaction_set::const_iterator it)
     {
-        return TxMempoolInfo{it->GetSharedTx(), it->GetTime(), it->GetFee(), it->GetTxSize(), it->GetModifiedFee() - it->GetFee()};
+        return TxMempoolInfo{it->GetSharedTx(), it->GetTime(), it->GetFee(), it->GetTxSize(),
+                             it->GetModifiedFee() - it->GetFee(), it->GetPriority()};
     }
 
 public:


### PR DESCRIPTION
## Summary
- add placeholder TestNet4 base parameters and selection logic
- include transaction priority when returning mempool info
- provide node namespace wrapper for TestBlockValidity
- avoid narrowing when parsing `-posactivationheight`

## Testing
- `cmake -G Ninja ..`
- `ninja src/CMakeFiles/bitcoin_common.dir/chainparamsbase.cpp.o src/CMakeFiles/bitcoin_common.dir/chainparams.cpp.o src/CMakeFiles/bitcoin_node.dir/node/compat_wrappers.cpp.o src/CMakeFiles/bitcoin_node.dir/txmempool.cpp.o`
- `ninja test` *(fails: Unable to find executable: /workspace/bitcoin/build/bin/test_bitcoin)*

------
https://chatgpt.com/codex/tasks/task_b_68beec8a1058832a91f2cde4b4a4a05b