### PR TITLE
Use -staking flag and add RPC check

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Staking
 -------
 
 To participate in BitGold's proof-of-stake, run `bitgoldd` or `bitgold-qt` with
-`-staker`, or add `staker=1` to `bitgold.conf`. The staking status can be
-checked with `bitgold-cli stakerstatus`. The staking engine uses the
+`-staking`, or add `staking=1` to `bitgold.conf`. The staking status can be
+checked with `bitgold-cli getstakinginfo`. The staking engine uses the
 PoS 3.1 consensus rules described in
 [doc/pos3.1-overview.md](doc/pos3.1-overview.md).
 

--- a/doc/bitgoldstaking.md
+++ b/doc/bitgoldstaking.md
@@ -19,20 +19,20 @@ These rules are enforced automatically when staking is enabled.
 
 ## Enabling
 
-Start the node with `-staker=1` (or add `staker=1` to `bitcoin.conf`) to run
+Start the node with `-staking=1` (or add `staking=1` to `bitcoin.conf`) to run
 the staking thread. No additional configuration is required for PoSV3, but
 `-debug=staking` may be useful for troubleshooting.
 
 ## Monitoring
 
-Use the `stakerstatus` RPC to check if staking is enabled and running:
+Use the `getstakinginfo` RPC to check if staking is enabled and running:
 
 ```
-$ bitcoin-cli stakerstatus
+$ bitcoin-cli getstakinginfo
 {
   "enabled": true,
   "staking": true
 }
 ```
 
-The `enabled` field indicates whether the `-staker` option is set, while `staking` shows if the staking thread is currently active.
+The `enabled` field indicates whether the `-staking` option is set, while `staking` shows if the staking thread is currently active.

--- a/doc/staking.md
+++ b/doc/staking.md
@@ -23,7 +23,7 @@ described below.
    ```
 3. Use `bitgold-cli getstakinginfo` to verify that your node is staking.
 
-The staker will automatically attempt to create new blocks at the protocol's
+The staking thread will automatically attempt to create new blocks at the protocol's
 8-minute target spacing. Staking rewards follow BitGold's 90 000-block halving
 schedule. The staking thread adheres to PoSV3 without additional options, but
 `-debug=staking` can help diagnose failures.

--- a/src/dummywallet.cpp
+++ b/src/dummywallet.cpp
@@ -41,7 +41,7 @@ void DummyWalletInit::AddWalletOptions(ArgsManager& argsman) const
         "-paytxfee=<amt>",
         "-signer=<cmd>",
         "-spendzeroconfchange",
-        "-staker",
+        "-staking",
         "-txconfirmtarget=<n>",
         "-wallet=<path>",
         "-walletbroadcast",

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -75,7 +75,7 @@ void WalletInit::AddWalletOptions(ArgsManager& argsman) const
 #endif
     argsman.AddArg("-walletrbf", strprintf("Send transactions with full-RBF opt-in enabled (RPC only, default: %u)", DEFAULT_WALLET_RBF), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
 
-    argsman.AddArg("-staker", "Enable the BitGold staking thread (default: false)", ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
+    argsman.AddArg("-staking", "Enable the BitGold staking thread (default: false)", ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
 
     argsman.AddArg("-unsafesqlitesync", "Set SQLite synchronous=OFF to disable waiting for the database to sync to disk. This is unsafe and can cause data loss and corruption. This option is only used by tests to improve their performance (default: false)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::WALLET_DEBUG_TEST);
 

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -851,30 +851,6 @@ static RPCHelpMan createwalletdescriptor()
                       }};
 }
 
-static RPCHelpMan stakerstatus()
-{
-    return RPCHelpMan{
-        "stakerstatus",
-        "Returns the staking status for this wallet.\n",
-        {},
-        RPCResult{
-            RPCResult::Type::OBJ, "", "", {
-                                              {RPCResult::Type::BOOL, "enabled", "true if staking is enabled via -staker"},
-                                              {RPCResult::Type::BOOL, "staking", "true if the staking thread is running"},
-                                          }},
-        RPCExamples{HelpExampleCli("stakerstatus", "") + HelpExampleRpc("stakerstatus", "")},
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
-            const std::shared_ptr<const CWallet> pwallet = GetWalletForJSONRPCRequest(request);
-            if (!pwallet) return UniValue::VNULL;
-            pwallet->BlockUntilSyncedToCurrentChain();
-
-            UniValue obj(UniValue::VOBJ);
-            obj.pushKV("enabled", gArgs.GetBoolArg("-staker", false));
-            obj.pushKV("staking", pwallet->IsStaking());
-            return obj;
-        }};
-}
-
 static RPCHelpMan getstakinginfo()
 {
     return RPCHelpMan{
@@ -883,12 +859,19 @@ static RPCHelpMan getstakinginfo()
         {},
         RPCResult{
             RPCResult::Type::OBJ, "", "", {
-                                              {RPCResult::Type::BOOL, "enabled", "true if staking is enabled via -staker"},
+                                              {RPCResult::Type::BOOL, "enabled", "true if staking is enabled via -staking"},
                                               {RPCResult::Type::BOOL, "staking", "true if the staking thread is running"},
                                           }},
         RPCExamples{HelpExampleCli("getstakinginfo", "") + HelpExampleRpc("getstakinginfo", "")},
-        [](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
-            return stakerstatus().HandleRequest(request);
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
+            const std::shared_ptr<const CWallet> pwallet = GetWalletForJSONRPCRequest(request);
+            if (!pwallet) return UniValue::VNULL;
+            pwallet->BlockUntilSyncedToCurrentChain();
+
+            UniValue obj(UniValue::VOBJ);
+            obj.pushKV("enabled", gArgs.GetBoolArg("-staking", false));
+            obj.pushKV("staking", pwallet->IsStaking());
+            return obj;
         }};
 }
 
@@ -1093,7 +1076,6 @@ std::span<const CRPCCommand> GetWalletRPCCommands()
         {"wallet", &walletpassphrase},
         {"wallet", &walletpassphrasechange},
         {"wallet", &walletprocesspsbt},
-        {"wallet", &stakerstatus},
         {"wallet", &getstakinginfo},
         {"wallet", &getstakingstats},
         {"wallet", &walletstaking},

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3221,7 +3221,7 @@ void CWallet::postInitProcess()
     WITH_LOCK(cs_wallet, chain().requestMempoolTransactions(*this));
 
     // Start staking thread if enabled
-    if (gArgs.GetBoolArg("-staker", false) && !m_staker) {
+    if (gArgs.GetBoolArg("-staking", false) && !m_staker) {
         m_staker = std::make_unique<BitGoldStaker>(*this);
         m_staker->Start();
     }

--- a/test/functional/wallet_staking_flag.py
+++ b/test/functional/wallet_staking_flag.py
@@ -1,0 +1,16 @@
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+class WalletStakingFlagTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.extra_args = [["-staking=1"], []]
+
+    def run_test(self):
+        info_enabled = self.nodes[0].getstakinginfo()
+        assert_equal(info_enabled["enabled"], True)
+        info_disabled = self.nodes[1].getstakinginfo()
+        assert_equal(info_disabled["enabled"], False)
+
+if __name__ == '__main__':
+    WalletStakingFlagTest().main()


### PR DESCRIPTION
## Summary
- rename wallet option to `-staking`
- update `getstakinginfo` RPC and start-up logic
- refresh staking documentation and add functional test

## Testing
- `python3 test/lint/lint-python.py test/functional/wallet_staking_flag.py` *(fails: lief not installed)*
- `python3 test/lint/check-doc.py` *(fails: Please document the following arguments: {'-posactivationheight'})*
- `test/functional/test_runner.py wallet_staking_flag.py` *(fails: FileNotFoundError: config.ini)*

------
https://chatgpt.com/codex/tasks/task_b_68c18ce7d660832a915e2e8054749257