### PR TITLE
feat: add delegated cold staking scaffolding

### DIFF
--- a/doc/staking.md
+++ b/doc/staking.md
@@ -54,3 +54,29 @@ The helper script `contrib/stake_monitor.py` automates this check:
 ```
 $ python3 contrib/stake_monitor.py
 ```
+
+## Cold staking
+
+BitGold supports delegating staking rights to an online node while keeping the
+spending key offline. To create a cold‑stake address:
+
+1. Generate an owner (spending) address in the offline wallet and a staking
+   address on the online node.
+2. On either system, call:
+
+   ```
+   bitcoin-cli delegatestakeaddress "OWNER_ADDR" "STAKER_ADDR"
+   ```
+
+   This returns a P2SH address and redeem script. Send coins to the returned
+   address.
+3. On the staking node, register the address:
+
+   ```
+   bitcoin-cli registercoldstakeaddress "DELEGATE_ADDR" "REDEEM_SCRIPT"
+   ```
+
+   The staking thread will now include the delegated coins when attempting to
+   create blocks.
+4. To spend the staked rewards, use the owner wallet with the original private
+   key.

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -12,11 +12,15 @@
 #include <rpc/util.h>
 #include <univalue.h>
 #include <util/translation.h>
+#include <script/script.h>
+#include <util/strencodings.h>
+#include <addresstype.h>
 #include <wallet/context.h>
 #include <wallet/receive.h>
 #include <wallet/rpc/util.h>
 #include <wallet/rpc/wallet.h>
 #include <wallet/wallet.h>
+#include <wallet/walletdb.h>
 #include <wallet/walletutil.h>
 
 #include <optional>
@@ -851,6 +855,81 @@ static RPCHelpMan createwalletdescriptor()
                       }};
 }
 
+static CScript CreateDelegatedStakeScript(const CKeyID& owner, const CKeyID& staker)
+{
+    CScript script;
+    script << OP_DUP << OP_HASH160 << ToByteVector(owner) << OP_EQUALVERIFY << OP_CHECKSIGVERIFY
+           << OP_DUP << OP_HASH160 << ToByteVector(staker) << OP_EQUALVERIFY << OP_CHECKSIG;
+    return script;
+}
+
+static RPCHelpMan delegatestakeaddress()
+{
+    return RPCHelpMan{
+        "delegatestakeaddress",
+        "Create a delegated cold-stake address.\n",
+        {
+            {"owner", RPCArg::Type::STR, RPCArg::Optional::NO, "Spending address"},
+            {"staker", RPCArg::Type::STR, RPCArg::Optional::NO, "Staking address"},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "", {
+            {RPCResult::Type::STR, "address", "Cold stake P2SH address"},
+            {RPCResult::Type::STR, "script", "Redeem script in hex"},
+        }},
+        RPCExamples{HelpExampleCli("delegatestakeaddress", "\"owner\" \"staker\"")},
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
+            const CTxDestination owner_dest = DecodeDestination(request.params[0].get_str());
+            const CTxDestination staker_dest = DecodeDestination(request.params[1].get_str());
+            if (!IsValidDestination(owner_dest) || !IsValidDestination(staker_dest)) {
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid address");
+            }
+            const PKHash* owner_key = std::get_if<PKHash>(&owner_dest);
+            const PKHash* staker_key = std::get_if<PKHash>(&staker_dest);
+            if (!owner_key || !staker_key) {
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Addresses must be P2PKH");
+            }
+            CScript redeem = CreateDelegatedStakeScript(ToKeyID(*owner_key), ToKeyID(*staker_key));
+            CTxDestination p2sh_dest = ScriptHash(redeem);
+            UniValue ret(UniValue::VOBJ);
+            ret.pushKV("address", EncodeDestination(p2sh_dest));
+            ret.pushKV("script", HexStr(redeem));
+            return ret;
+        }
+    };
+}
+
+static RPCHelpMan registercoldstakeaddress()
+{
+    return RPCHelpMan{
+        "registercoldstakeaddress",
+        "Register a cold-stake address for staking.\n",
+        {
+            {"address", RPCArg::Type::STR, RPCArg::Optional::NO, "Cold stake P2SH address"},
+            {"script", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "Redeem script in hex"},
+        },
+        RPCResult{RPCResult::Type::BOOL, "", "success"},
+        RPCExamples{HelpExampleCli("registercoldstakeaddress", "\"address\" \"script\"")},
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
+            std::shared_ptr<CWallet> pwallet = GetWalletForJSONRPCRequest(request);
+            if (!pwallet) return UniValue::VNULL;
+            pwallet->BlockUntilSyncedToCurrentChain();
+            CTxDestination dest = DecodeDestination(request.params[0].get_str());
+            if (!IsValidDestination(dest)) {
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid address");
+            }
+            std::vector<unsigned char> rs_data = ParseHex(request.params[1].get_str());
+            CScript redeem(rs_data.begin(), rs_data.end());
+            LegacyDataSPKM* spkm = pwallet->GetOrCreateLegacyDataSPKM();
+            spkm->LoadCScript(redeem);
+            CScript script_pub = GetScriptForDestination(ScriptHash(redeem));
+            spkm->LoadWatchOnly(script_pub);
+            WalletBatch batch(pwallet->GetDatabase());
+            batch.WriteWatchOnly(script_pub, CKeyMetadata{});
+            return UniValue(true);
+        }
+    };
+}
+
 static RPCHelpMan stakerstatus()
 {
     return RPCHelpMan{
@@ -1093,6 +1172,8 @@ std::span<const CRPCCommand> GetWalletRPCCommands()
         {"wallet", &walletpassphrase},
         {"wallet", &walletpassphrasechange},
         {"wallet", &walletprocesspsbt},
+        {"wallet", &delegatestakeaddress},
+        {"wallet", &registercoldstakeaddress},
         {"wallet", &stakerstatus},
         {"wallet", &getstakinginfo},
         {"wallet", &getstakingstats},

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3252,8 +3252,10 @@ std::vector<COutput> CWallet::GetStakeableCoins(int min_depth, std::chrono::seco
 {
     std::vector<COutput> candidates;
     LOCK(cs_wallet);
-    for (const COutput& out : AvailableCoins(*this).All()) {
-        if (!out.spendable) continue;
+    CoinFilterParams params;
+    params.only_spendable = false;
+    for (const COutput& out : AvailableCoins(*this, /*coinControl=*/nullptr, /*feerate=*/std::nullopt, params).All()) {
+        if (!out.spendable && !out.solvable) continue;
         if (out.depth < min_depth) continue;
         if (out.txout.nValue < min_amount) continue;
         if (min_age.count() > 0) {

--- a/test/functional/wallet_coldstake.py
+++ b/test/functional/wallet_coldstake.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+class WalletColdStakeTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+
+    def run_test(self):
+        node = self.nodes[0]
+        owner = node.getnewaddress()
+        staker = node.getnewaddress()
+        res = node.delegatestakeaddress(owner, staker)
+        cold_addr = res['address']
+        script = res['script']
+        node.registercoldstakeaddress(cold_addr, script)
+        info = node.getaddressinfo(cold_addr)
+        assert info['iswatchonly']
+
+if __name__ == '__main__':
+    WalletColdStakeTest().main()


### PR DESCRIPTION
## Summary
- allow watch-only delegated scripts to be staked
- add RPC commands for creating and registering cold-stake addresses
- document cold-stake setup and include basic functional test

## Testing
- `cmake ..`
- `make -j2 bitcoind bitcoin-cli` *(fails: undefined reference to ChainstateManager::* )*


------
https://chatgpt.com/codex/tasks/task_b_68c1a969387c832ab8987521004edfe5