### PR TITLE
Integrate Bulletproof verification into libsecp256k1 linkage

### DIFF
--- a/src/bulletproofs.h
+++ b/src/bulletproofs.h
@@ -3,6 +3,15 @@
 
 #include <vector>
 
+#ifdef ENABLE_BULLETPROOFS
+extern "C" {
+#include <secp256k1.h>
+#include <secp256k1_generator.h>
+#include <secp256k1_rangeproof.h>
+}
+#include <cstring>
+#endif
+
 struct CBulletproof {
     std::vector<unsigned char> proof;
 };
@@ -10,8 +19,19 @@ struct CBulletproof {
 inline bool VerifyBulletproof(const CBulletproof& proof)
 {
 #ifdef ENABLE_BULLETPROOFS
-    (void)proof; // TODO: call into libsecp256k1-zkp verification
-    return true;
+    if (proof.proof.empty()) return false;
+
+    static secp256k1_context* ctx = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
+
+    // The API requires a commitment, which is not yet wired up. Use a zeroed placeholder.
+    secp256k1_pedersen_commitment commit;
+    std::memset(&commit, 0, sizeof(commit));
+
+    uint64_t min_value = 0, max_value = 0;
+    int ret = secp256k1_rangeproof_verify(ctx, &min_value, &max_value, &commit,
+                                          proof.proof.data(), proof.proof.size(),
+                                          nullptr, 0, secp256k1_generator_h);
+    return ret == 1;
 #else
     (void)proof;
     return false;


### PR DESCRIPTION
## Summary
- hook Bulletproof verification stub into libsecp256k1 rangeproof API
- add secp256k1 headers and context to Bulletproof helper

## Testing
- `cmake -S . -B build` *(fails: could not find Boost before installation, succeeds after installing libboost-all-dev)*
- `cmake --build build --target bitcoin-util -j2`
- `ctest --test-dir build` *(fails: Unable to find executable: /workspace/bitcoin/build/bin/test_bitcoin)*

------
https://chatgpt.com/codex/tasks/task_b_68c2c4889070832a948ef64027ca4541