### PR TITLE
Add block signature field to CBlock and wire up usage

### DIFF
--- a/src/bench/readwriteblock.cpp
+++ b/src/bench/readwriteblock.cpp
@@ -24,6 +24,7 @@ static CBlock CreateTestBlock()
     DataStream stream{benchmark::data::block413567};
     CBlock block;
     stream >> TX_WITH_WITNESS(block);
+    block.vchBlockSig.clear();
     return block;
 }
 

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -55,6 +55,7 @@ static CBlock CreateGenesisBlock(const char* pszTimestamp, const CScript& genesi
     genesis.vtx.push_back(MakeTransactionRef(std::move(txNew)));
     genesis.hashPrevBlock.SetNull();
     genesis.hashMerkleRoot = BlockMerkleRoot(genesis);
+    genesis.vchBlockSig.clear();
     return genesis;
 }
 

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -184,6 +184,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock()
     UpdateTime(pblock, chainparams.GetConsensus(), pindexPrev);
     pblock->nBits          = pindexPrev->nBits;
     pblock->nNonce         = 0;
+    pblock->vchBlockSig.clear();
 
     if (m_options.test_block_validity) {
         if (BlockValidationState state{TestBlockValidity(m_chainstate, *pblock, /*check_pow=*/false, /*check_merkle_root=*/false)}; !state.IsValid()) {

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -400,6 +400,7 @@ CBlock TestChain100Setup::CreateBlock(
     RegenerateCommitments(block, *Assert(m_node.chainman));
 
     block.nNonce = 0;
+    block.vchBlockSig.clear();
 
     return block;
 }


### PR DESCRIPTION
## Summary
- add `vchBlockSig` to `CBlock` with serialization and reset handling
- initialize block signature when creating genesis blocks, mined blocks, and test blocks
- handle block signature in read/write benchmarks

## Testing
- `ninja -C build bitcoin-cli`
- `ninja -C build test_bitcoin` *(fails: script/standard.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68c2de7e81f4832a8397c8fd73fd3932