### PR TITLE
Add stake-related fields to block index serialization

### DIFF
--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -131,6 +131,11 @@ bool BlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, s
                 pindexNew->nTime          = diskindex.nTime;
                 pindexNew->nBits          = diskindex.nBits;
                 pindexNew->nNonce         = diskindex.nNonce;
+                pindexNew->fProofOfStake  = diskindex.fProofOfStake;
+                pindexNew->hashProofOfStake = diskindex.hashProofOfStake;
+                pindexNew->nStakeModifier = diskindex.nStakeModifier;
+                pindexNew->nStakeModifierHeight = diskindex.nStakeModifierHeight;
+                pindexNew->nStakeModifierTime = diskindex.nStakeModifierTime;
                 pindexNew->nStatus        = diskindex.nStatus;
                 pindexNew->nTx            = diskindex.nTx;
 


### PR DESCRIPTION
## Summary
- track proof-of-stake metadata directly in `CBlockIndex`
- persist stake fields to disk with backward-compatible serialization
- populate stake metadata when loading block indexes

## Testing
- `ninja -C build test_bitcoin` *(fails: script/standard.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68c2de810544832aa79041bf643680e9