### PR TITLE
Add basic wallet staking support

### DIFF
--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(bitcoin_wallet STATIC EXCLUDE_FROM_ALL
   feebumper.cpp
   fees.cpp
   bitgoldstaker.cpp
+  stake.cpp
   interfaces.cpp
   load.cpp
   migrate.cpp

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -78,6 +78,10 @@ void WalletInit::AddWalletOptions(ArgsManager& argsman) const
     argsman.AddArg("-staker", "Enable the BitGold staking thread (default: false)", ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     argsman.AddArg("-staking", "Enable the BitGold staking thread (alias of -staker, default: false)", ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
 
+    argsman.AddArg("-reservebalance=<amt>",
+                   strprintf("Keep the specified amount (in %s) reserved and not used for staking (default: 0)", CURRENCY_UNIT),
+                   ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
+
     argsman.AddArg("-unsafesqlitesync", "Set SQLite synchronous=OFF to disable waiting for the database to sync to disk. This is unsafe and can cause data loss and corruption. This option is only used by tests to improve their performance (default: false)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::WALLET_DEBUG_TEST);
 
     argsman.AddArg("-walletrejectlongchains", strprintf("Wallet will not create transactions that violate mempool chain limits (default: %u)", DEFAULT_WALLET_REJECT_LONG_CHAINS), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::WALLET_DEBUG_TEST);

--- a/src/wallet/stake.cpp
+++ b/src/wallet/stake.cpp
@@ -1,0 +1,190 @@
+#include <chrono>
+#include <consensus/amount.h>
+#include <consensus/consensus.h>
+#include <consensus/merkle.h>
+#include <interfaces/chain.h>
+#include <node/context.h>
+#include <pos/stake.h>
+#include <util/time.h>
+#include <validation.h>
+#include <wallet/stake.h>
+#include <wallet/wallet.h>
+#include <wallet/spend.h>
+
+#include <algorithm>
+#include <logging.h>
+#include <vector>
+
+namespace wallet {
+
+Stake::Stake(CWallet& wallet) : m_wallet(wallet) {}
+
+Stake::~Stake()
+{
+    Stop();
+}
+
+void Stake::Start()
+{
+    if (m_thread.joinable()) return;
+    m_stop = false;
+    m_thread = std::thread(&Stake::ThreadStakeMiner, this);
+}
+
+void Stake::Stop()
+{
+    m_stop = true;
+    if (m_thread.joinable()) m_thread.join();
+}
+
+bool Stake::IsActive() const
+{
+    return m_thread.joinable() && !m_stop;
+}
+
+void Stake::ThreadStakeMiner()
+{
+    interfaces::Chain& chain = m_wallet.chain();
+    node::NodeContext* node_context = chain.context();
+    if (!node_context || !node_context->chainman) {
+        LogDebug(BCLog::STAKING, "ThreadStakeMiner: chainman unavailable\n");
+        return;
+    }
+    ChainstateManager& chainman = *node_context->chainman;
+    const Consensus::Params& consensus = chainman.GetParams().GetConsensus();
+    const CAmount MIN_STAKE_AMOUNT{1 * COIN};
+    const int MIN_STAKE_DEPTH{COINBASE_MATURITY};
+
+    std::chrono::milliseconds sleep_time{500};
+    while (!m_stop) {
+        bool staked{false};
+        try {
+            int chain_height;
+            {
+                LOCK(::cs_main);
+                chain_height = chainman.ActiveChain().Height();
+            }
+            const int min_depth = chain_height < MIN_STAKE_DEPTH ? 0 : MIN_STAKE_DEPTH;
+            const std::chrono::seconds min_age{consensus.nStakeMinAge};
+
+            std::vector<COutput> candidates = m_wallet.GetStakeableCoins(min_depth, min_age, MIN_STAKE_AMOUNT);
+
+            CAmount total_value{0};
+            for (const COutput& o : candidates) total_value += o.txout.nValue;
+            if (total_value <= m_wallet.GetReserveBalance()) {
+                LogDebug(BCLog::STAKING, "ThreadStakeMiner: balance below reserve\n");
+                candidates.clear();
+            }
+
+            if (!candidates.empty()) {
+                CBlockIndex* pindexPrev;
+                {
+                    LOCK(::cs_main);
+                    pindexPrev = chainman.ActiveChain().Tip();
+                }
+                if (pindexPrev) {
+                    for (const COutput& stake_out : candidates) {
+                        uint256 confirmed_block_hash;
+                        {
+                            LOCK(m_wallet.cs_wallet);
+                            const CWalletTx* wtx = m_wallet.GetWalletTx(stake_out.outpoint.hash);
+                            if (!wtx) continue;
+                            auto* conf = wtx->state<TxStateConfirmed>();
+                            if (!conf) continue;
+                            confirmed_block_hash = conf->confirmed_block_hash;
+                        }
+                        const CBlockIndex* pindexFrom;
+                        {
+                            LOCK(::cs_main);
+                            pindexFrom = chainman.m_blockman.LookupBlockIndex(confirmed_block_hash);
+                        }
+                        if (!pindexFrom) continue;
+
+                        unsigned int nTimeTx = std::max<int64_t>(pindexPrev->GetMedianTimePast() + 1,
+                                                                 TicksSinceEpoch<std::chrono::seconds>(NodeClock::now()));
+                        nTimeTx &= ~consensus.nStakeTimestampMask;
+                        unsigned int nBits = pindexPrev->nBits;
+                        uint256 hash_proof;
+                        if (!CheckStakeKernelHash(pindexPrev, nBits, pindexFrom->GetBlockHash(),
+                                                  pindexFrom->nTime, stake_out.txout.nValue, stake_out.outpoint,
+                                                  nTimeTx, hash_proof, true, consensus)) {
+                            continue;
+                        }
+
+                        CMutableTransaction coinstake;
+                        coinstake.nLockTime = nTimeTx;
+                        coinstake.vin.emplace_back(stake_out.outpoint);
+                        coinstake.vin[0].nSequence = CTxIn::SEQUENCE_FINAL;
+                        coinstake.vout.resize(2);
+                        coinstake.vout[0].SetNull();
+
+                        CAmount reward = GetBlockSubsidy(pindexPrev->nHeight + 1, consensus);
+                        CAmount total = stake_out.txout.nValue + reward;
+                        CAmount split_threshold = 2 * MIN_STAKE_AMOUNT;
+                        if (total > split_threshold * 2) {
+                            CAmount half = total / 2;
+                            coinstake.vout.emplace_back(half, stake_out.txout.scriptPubKey);
+                            coinstake.vout.emplace_back(total - half, stake_out.txout.scriptPubKey);
+                        } else {
+                            coinstake.vout[1].nValue = total;
+                            coinstake.vout[1].scriptPubKey = stake_out.txout.scriptPubKey;
+                        }
+
+                        {
+                            LOCK(m_wallet.cs_wallet);
+                            if (!m_wallet.SignTransaction(coinstake)) continue;
+                        }
+
+                        CMutableTransaction coinbase;
+                        coinbase.vin.resize(1);
+                        coinbase.vin[0].prevout.SetNull();
+                        coinbase.vin[0].nSequence = CTxIn::MAX_SEQUENCE_NONFINAL;
+                        coinbase.vin[0].scriptSig = CScript() << (pindexPrev->nHeight + 1) << OP_0;
+                        coinbase.vout.resize(1);
+                        coinbase.vout[0].nValue = 0;
+                        coinbase.nLockTime = pindexPrev->nHeight + 1;
+
+                        CBlock block;
+                        block.vtx.emplace_back(MakeTransactionRef(std::move(coinbase)));
+                        block.vtx.emplace_back(MakeTransactionRef(std::move(coinstake)));
+                        block.hashPrevBlock = pindexPrev->GetBlockHash();
+                        block.nVersion = chainman.m_versionbitscache.ComputeBlockVersion(pindexPrev, consensus);
+                        block.nTime = nTimeTx;
+                        block.nBits = pindexPrev->nBits;
+                        block.nNonce = 0;
+                        block.hashMerkleRoot = BlockMerkleRoot(block);
+
+                        {
+                            LOCK(cs_main);
+                            if (!ContextualCheckProofOfStake(block, pindexPrev,
+                                                              chainman.ActiveChainstate().CoinsTip(),
+                                                              chainman.ActiveChain(), consensus)) {
+                                continue;
+                            }
+                        }
+
+                        bool new_block{false};
+                        if (!chainman.ProcessNewBlock(std::make_shared<const CBlock>(block),
+                                                      /*force_processing=*/true, /*min_pow_checked=*/true,
+                                                      &new_block)) {
+                            continue;
+                        }
+                        LogPrintLevel(BCLog::STAKING, BCLog::Level::Info,
+                                      "ThreadStakeMiner: staked block %s\n",
+                                      block.GetHash().ToString());
+                        staked = true;
+                        break;
+                    }
+                }
+            }
+        } catch (const std::exception& e) {
+            LogDebug(BCLog::STAKING, "ThreadStakeMiner exception: %s\n", e.what());
+        }
+
+        sleep_time = staked ? std::chrono::milliseconds{500}
+                             : std::min(sleep_time * 2, std::chrono::milliseconds{8000});
+        std::this_thread::sleep_for(sleep_time);
+    }
+}
+
+} // namespace wallet

--- a/src/wallet/stake.h
+++ b/src/wallet/stake.h
@@ -1,0 +1,41 @@
+#ifndef BITCOIN_WALLET_STAKE_H
+#define BITCOIN_WALLET_STAKE_H
+
+#include <atomic>
+#include <thread>
+
+namespace wallet {
+
+class CWallet;
+
+/**
+ * Stake runs a background thread to look for proof-of-stake opportunities
+ * by scanning wallet UTXOs for eligible kernels and submitting blocks.
+ * The implementation is intentionally simple and experimental.
+ */
+class Stake
+{
+public:
+    explicit Stake(CWallet& wallet);
+    ~Stake();
+
+    /** Start the staking thread. */
+    void Start();
+    /** Stop the staking thread. */
+    void Stop();
+    /** Return true if the staking thread is active. */
+    bool IsActive() const;
+
+private:
+    /** Main staking thread loop. Scans for kernels, creates and signs
+     *  coinstake transactions and blocks. */
+    void ThreadStakeMiner();
+
+    CWallet& m_wallet;
+    std::thread m_thread;
+    std::atomic<bool> m_stop{false};
+};
+
+} // namespace wallet
+
+#endif // BITCOIN_WALLET_STAKE_H

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3221,6 +3221,15 @@ void CWallet::postInitProcess()
     // Update wallet transactions with current mempool transactions.
     WITH_LOCK(cs_wallet, chain().requestMempoolTransactions(*this));
 
+    if (gArgs.IsArgSet("-reservebalance")) {
+        CAmount amount{0};
+        if (ParseMoney(gArgs.GetArg("-reservebalance", "0"), amount)) {
+            SetReserveBalance(amount);
+        } else {
+            LogPrintf("Invalid -reservebalance amount, ignoring\n");
+        }
+    }
+
     // Start staking thread if enabled
     if (gArgs.GetBoolArg("-staker", false) || gArgs.GetBoolArg("-staking", false)) {
         StartStakeMiner();
@@ -3230,7 +3239,7 @@ void CWallet::postInitProcess()
 void CWallet::StartStakeMiner()
 {
     if (!m_staker) {
-        m_staker = std::make_unique<BitGoldStaker>(*this);
+        m_staker = std::make_unique<Stake>(*this);
     }
     if (!m_staker->IsActive()) {
         m_staker->Start();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -28,7 +28,7 @@
 #include <util/time.h>
 #include <util/transaction_identifier.h>
 #include <util/ui_change_type.h>
-#include <wallet/bitgoldstaker.h>
+#include <wallet/stake.h>
 #include <wallet/crypter.h>
 #include <wallet/db.h>
 #include <wallet/scriptpubkeyman.h>
@@ -90,7 +90,6 @@ struct bilingual_str;
 
 namespace wallet {
 struct WalletContext;
-class BitGoldStaker;
 
 //! Explicitly delete the wallet.
 //! Blocks the current thread until the wallet is destructed.
@@ -548,7 +547,7 @@ public:
     std::unique_ptr<interfaces::Handler> m_chain_notifications_handler;
 
     /** Proof-of-stake staker thread. */
-    std::unique_ptr<BitGoldStaker> m_staker;
+    std::unique_ptr<Stake> m_staker;
 
     /** Cached staking statistics. */
     StakingStats m_staking_stats GUARDED_BY(cs_wallet);


### PR DESCRIPTION
## Summary
- add wallet Stake thread for scanning UTXOs and producing proof-of-stake blocks
- allow configuring reserve balance via -reservebalance flag and start staking when enabled
- wire staking thread into wallet lifecycle

## Testing
- `cmake -S . -B build -GNinja`
- `ninja -C build bitcoin-wallet` *(fails: script/standard.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68c2de836b60832ab0e334ad5f3a9b8f