### PR TITLE
Implement Bulletproof RPC logic and add functional tests

### DIFF
--- a/src/rpc/bulletproof.cpp
+++ b/src/rpc/bulletproof.cpp
@@ -6,6 +6,15 @@
 #include <rpc/util.h>
 #include <univalue.h>
 
+#include <core_io.h>
+#include <primitives/transaction.h>
+#include <rpc/rawtransaction_util.h>
+#include <util/strencodings.h>
+#ifdef ENABLE_BULLETPROOFS
+#include <bulletproofs.h>
+#include <random.h>
+#endif
+
 static RPCHelpMan createrawbulletprooftransaction()
 {
     return RPCHelpMan{"createrawbulletprooftransaction",
@@ -18,6 +27,7 @@ static RPCHelpMan createrawbulletprooftransaction()
             RPCResult::Type::OBJ, "", "",
             {
                 {RPCResult::Type::STR_HEX, "hex", "The serialized transaction in hex."},
+                {RPCResult::Type::STR_HEX, "proof", "Bulletproof range proof for the first output."},
             }
         },
         RPCExamples{
@@ -29,10 +39,56 @@ static RPCHelpMan createrawbulletprooftransaction()
 #ifndef ENABLE_BULLETPROOFS
             throw JSONRPCError(RPC_MISC_ERROR, "Bulletproofs not enabled");
 #else
+            const UniValue& inputs = request.params[0];
+            const UniValue& outputs = request.params[1];
+
+            if (!inputs.isArray()) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "Inputs must be an array");
+            }
+            if (!outputs.isObject()) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "Outputs must be an object");
+            }
+
+            // Build the transaction using existing raw transaction helpers
+            CMutableTransaction mtx;
+            try {
+                mtx = ConstructTransaction(inputs, outputs, NullUniValue, std::nullopt);
+            } catch (const std::exception& e) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("Transaction construction failed: ") + e.what());
+            }
+
             UniValue result(UniValue::VOBJ);
-            // Placeholder implementation. Real implementation constructs a
-            // transaction using confidential outputs and Bulletproof proofs.
-            result.pushKV("hex", "00");
+            result.pushKV("hex", EncodeHexTx(CTransaction(mtx)));
+
+            // Generate a Bulletproof for the first output amount
+            if (mtx.vout.empty()) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "Transaction must have at least one output");
+            }
+
+            CBulletproof bp;
+            CAmount amount = mtx.vout[0].nValue;
+
+            unsigned char blind[32];
+            GetRandBytes({blind, 32});
+
+            static secp256k1_context* ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+
+            if (secp256k1_pedersen_commit(ctx, &bp.commitment, blind, amount, &secp256k1_generator_h) != 1) {
+                throw JSONRPCError(RPC_MISC_ERROR, "Failed to create commitment");
+            }
+
+            bp.proof.resize(SECP256K1_RANGE_PROOF_MAX_LENGTH);
+            size_t proof_len = bp.proof.size();
+            if (secp256k1_rangeproof_sign(ctx, bp.proof.data(), &proof_len, 0, &bp.commitment, blind, nullptr, 0, 0, amount, &secp256k1_generator_h) != 1) {
+                throw JSONRPCError(RPC_MISC_ERROR, "Failed to generate Bulletproof");
+            }
+            bp.proof.resize(proof_len);
+            bp.extra.clear();
+
+            CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+            ss << bp;
+            result.pushKV("proof", HexStr(ss));
+
             return result;
 #endif
         }
@@ -56,9 +112,20 @@ static RPCHelpMan verifybulletproof()
 #ifndef ENABLE_BULLETPROOFS
             throw JSONRPCError(RPC_MISC_ERROR, "Bulletproofs not enabled");
 #else
-            const std::string proof = request.params[0].get_str();
-            // Placeholder verification: succeed if proof length is even.
-            return proof.size() % 2 == 0;
+            const std::string proof_hex = request.params[0].get_str();
+            if (!IsHex(proof_hex)) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "Proof must be hex encoded");
+            }
+            const std::vector<unsigned char> proof_bytes = ParseHex(proof_hex);
+            CBulletproof bp;
+            try {
+                CDataStream ss(proof_bytes, SER_NETWORK, PROTOCOL_VERSION);
+                ss >> bp;
+            } catch (const std::exception&) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "Failed to decode Bulletproof");
+            }
+
+            return VerifyBulletproof(bp);
 #endif
         }
     };

--- a/test/rpc/test_bulletproof.py
+++ b/test/rpc/test_bulletproof.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Functional tests for Bulletproof RPC calls."""
+
+import json
+import unittest
+import http.client
+from base64 import b64encode
+
+RPC_USER = "user"
+RPC_PASSWORD = "pass"
+RPC_PORT = 8332
+
+class BulletproofRPCTest(unittest.TestCase):
+    def rpc_call(self, method, params=None):
+        if params is None:
+            params = []
+        headers = {
+            "Authorization": "Basic " + b64encode(f"{RPC_USER}:{RPC_PASSWORD}".encode()).decode(),
+            "Content-Type": "application/json",
+        }
+        payload = json.dumps({"jsonrpc": "1.0", "id": "test", "method": method, "params": params})
+        conn = http.client.HTTPConnection("127.0.0.1", RPC_PORT)
+        try:
+            conn.request("POST", "/", payload, headers)
+            response = conn.getresponse()
+            return json.loads(response.read())
+        finally:
+            conn.close()
+
+    def setUp(self):
+        try:
+            self.rpc_call("getblockcount")
+        except Exception as e:
+            self.skipTest(f"RPC server not available: {e}")
+
+    def test_create_and_verify(self):
+        created = self.rpc_call("createrawbulletprooftransaction", [[], {"data": "00"}])
+        proof = created.get("result", {}).get("proof")
+        self.assertIsInstance(proof, str)
+        verified = self.rpc_call("verifybulletproof", [proof])
+        self.assertTrue(verified.get("result"))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Replace placeholder Bulletproof RPC methods with real transaction construction and proof generation/verification.
- Add functional test demonstrating Bulletproof transaction creation and proof validation.

## Testing
- `python3 test/rpc/test_bulletproof.py`

------
https://chatgpt.com/codex/tasks/task_b_68c2ff1b8ec0832a8f55ac4c3b2d4f9c