### PR TITLE
Add dividend tracking and RPC endpoints

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -326,6 +326,7 @@ add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
   rpc/signmessage.cpp
   rpc/bulletproof.cpp
   rpc/txoutproof.cpp
+  dividend/dividend.cpp
   $<$<TARGET_EXISTS:bitcoin_wallet>:rpc/staking.cpp>
   script/sigcache.cpp
   signet.cpp

--- a/src/dividend/dividend.cpp
+++ b/src/dividend/dividend.cpp
@@ -1,0 +1,29 @@
+#include <dividend/dividend.h>
+
+namespace dividend {
+
+Payouts CalculatePayouts(const std::map<std::string, StakeInfo>& stakes, int height, CAmount pool)
+{
+    Payouts payouts;
+    if (pool <= 0) return payouts;
+    long long total_weight_time = 0;
+    for (const auto& [addr, info] : stakes) {
+        int duration = height - info.last_payout_height;
+        if (duration > 0 && info.weight > 0) {
+            total_weight_time += static_cast<long long>(info.weight) * duration;
+        }
+    }
+    if (total_weight_time == 0) return payouts;
+    for (const auto& [addr, info] : stakes) {
+        int duration = height - info.last_payout_height;
+        if (duration > 0 && info.weight > 0) {
+            CAmount share = pool * static_cast<long long>(info.weight) * duration / total_weight_time;
+            if (share > 0) {
+                payouts.emplace(addr, share);
+            }
+        }
+    }
+    return payouts;
+}
+
+} // namespace dividend

--- a/src/dividend/dividend.h
+++ b/src/dividend/dividend.h
@@ -1,0 +1,27 @@
+#ifndef BITCOIN_DIVIDEND_DIVIDEND_H
+#define BITCOIN_DIVIDEND_DIVIDEND_H
+
+#include <consensus/amount.h>
+#include <map>
+#include <string>
+
+struct StakeInfo {
+    CAmount weight{0};
+    int last_payout_height{0};
+};
+
+namespace dividend {
+using Payouts = std::map<std::string, CAmount>;
+
+/**
+ * Calculate dividend payouts for a set of stakes.
+ * @param stakes map of address to StakeInfo
+ * @param height current block height
+ * @param pool total dividend pool to distribute
+ * @return map of address to payout amount
+ */
+Payouts CalculatePayouts(const std::map<std::string, StakeInfo>& stakes, int height, CAmount pool);
+
+} // namespace dividend
+
+#endif // BITCOIN_DIVIDEND_DIVIDEND_H

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -53,6 +53,7 @@
 #include <validation.h>
 #include <validationinterface.h>
 #include <versionbits.h>
+#include <dividend/dividend.h>
 
 #include <cstdint>
 
@@ -3452,6 +3453,69 @@ return RPCHelpMan{
     };
 }
 
+static RPCHelpMan getdividendinfo()
+{
+    return RPCHelpMan{
+        "getdividendinfo",
+        "Returns information about the dividend pool and stakes.",
+        {},
+        RPCResult{RPCResult::Type::OBJ, "", "", {
+            {RPCResult::Type::STR_AMOUNT, "pool", "Current dividend pool"},
+            {RPCResult::Type::OBJ, "stakes", "Stake info per address", {{RPCResult::Type::OBJ, "", "", {
+                {RPCResult::Type::STR_AMOUNT, "weight", "Current stake weight"},
+                {RPCResult::Type::NUM, "last_payout", "Height of last payout"},
+                {RPCResult::Type::STR_AMOUNT, "pending", "Pending dividend amount"},
+            }}}},
+        }},
+        RPCExamples{HelpExampleCli("getdividendinfo", "") + HelpExampleRpc("getdividendinfo", "")},
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
+            NodeContext& node = EnsureNodeContext(request.context);
+            LOCK(cs_main);
+            Chainstate& chainstate = EnsureChainman(node).ActiveChainstate();
+            UniValue result(UniValue::VOBJ);
+            result.pushKV("pool", ValueFromAmount(chainstate.GetDividendPool()));
+            UniValue stakes(UniValue::VOBJ);
+            for (const auto& [addr, info] : chainstate.GetStakeInfo()) {
+                UniValue obj(UniValue::VOBJ);
+                obj.pushKV("weight", ValueFromAmount(info.weight));
+                obj.pushKV("last_payout", info.last_payout_height);
+                auto it = chainstate.GetPendingDividends().find(addr);
+                obj.pushKV("pending", it != chainstate.GetPendingDividends().end() ? ValueFromAmount(it->second) : ValueFromAmount(0));
+                stakes.pushKV(addr, obj);
+            }
+            result.pushKV("stakes", stakes);
+            return result;
+        }
+    };
+}
+
+static RPCHelpMan claimdividends()
+{
+    return RPCHelpMan{
+        "claimdividends",
+        "Claim pending dividends for an address.",
+        {
+            {"address", RPCArg::Type::STR, RPCArg::Optional::NO, "Address to claim for"},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "", {
+            {RPCResult::Type::STR, "address", "Address"},
+            {RPCResult::Type::STR_AMOUNT, "amount", "Amount claimed"},
+        }},
+        RPCExamples{HelpExampleCli("claimdividends", "\"addr\"") + HelpExampleRpc("claimdividends", "\"addr\"")},
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
+            NodeContext& node = EnsureNodeContext(request.context);
+            LOCK(cs_main);
+            Chainstate& chainstate = EnsureChainman(node).ActiveChainstate();
+            std::string addr = request.params[0].get_str();
+            CAmount amount = chainstate.ClaimDividend(addr);
+            UniValue obj(UniValue::VOBJ);
+            obj.pushKV("address", addr);
+            obj.pushKV("amount", ValueFromAmount(amount));
+            return obj;
+        }
+    };
+}
+
 
 void RegisterBlockchainRPCCommands(CRPCTable& t)
 {
@@ -3481,6 +3545,8 @@ void RegisterBlockchainRPCCommands(CRPCTable& t)
         {"blockchain", &dumptxoutset},
         {"blockchain", &loadtxoutset},
         {"blockchain", &getchainstates},
+        {"blockchain", &getdividendinfo},
+        {"blockchain", &claimdividends},
         {"hidden", &invalidateblock},
         {"hidden", &reconsiderblock},
         {"hidden", &waitfornewblock},

--- a/src/validation.h
+++ b/src/validation.h
@@ -34,6 +34,7 @@
 #include <util/time.h>
 #include <util/translation.h>
 #include <versionbits.h>
+#include <dividend/dividend.h>
 
 #include <atomic>
 #include <cstdint>
@@ -620,6 +621,11 @@ public:
     //! Accumulated dividend fees awaiting distribution.
     CAmount m_dividend_pool GUARDED_BY(::cs_main){0};
 
+    //! Stake tracking per address.
+    std::map<std::string, StakeInfo> m_stake_info GUARDED_BY(::cs_main);
+    //! Pending dividends ready to be claimed by address.
+    std::map<std::string, CAmount> m_pending_dividends GUARDED_BY(::cs_main);
+
     /**
      * The base of the snapshot this chainstate was created from.
      *
@@ -654,6 +660,10 @@ public:
     void LoadDividendPool() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     void AddToDividendPool(CAmount amount, int height) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     CAmount GetDividendPool() const EXCLUSIVE_LOCKS_REQUIRED(::cs_main) { return m_dividend_pool; }
+    const std::map<std::string, StakeInfo>& GetStakeInfo() const EXCLUSIVE_LOCKS_REQUIRED(::cs_main) { return m_stake_info; }
+    const std::map<std::string, CAmount>& GetPendingDividends() const EXCLUSIVE_LOCKS_REQUIRED(::cs_main) { return m_pending_dividends; }
+    void UpdateStakeWeight(const std::string& addr, CAmount weight) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    CAmount ClaimDividend(const std::string& addr) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     //! @returns A pointer to the mempool.
     CTxMemPool* GetMempool()


### PR DESCRIPTION
## Summary
- track per-address staking weight and pending dividends
- compute dividend payouts based on stake duration and weight
- expose `getdividendinfo` and `claimdividends` RPCs

## Testing
- `cmake -B build -GNinja` *(fails: Could not find a package configuration file provided by "Boost")*


------
https://chatgpt.com/codex/tasks/task_b_68c3101600d0832abf0fffe4056fd0bf