### PR TITLE
Implement capped subsidy schedule

### DIFF
--- a/src/test/fuzz/utxo_total_supply.cpp
+++ b/src/test/fuzz/utxo_total_supply.cpp
@@ -122,6 +122,7 @@ FUZZ_TARGET(utxo_total_supply)
     current_block->hashMerkleRoot = BlockMerkleRoot(*current_block);
     assert(!MineBlock(node, current_block).IsNull());
     circulation += GetBlockSubsidy(ActiveHeight(), Params().GetConsensus());
+    assert(circulation <= (8'000'000 * COIN - 3'000'000 * COIN));
 
     assert(ActiveHeight() == 1);
     UpdateUtxoStats();
@@ -161,6 +162,7 @@ FUZZ_TARGET(utxo_total_supply)
                     }
 
                     circulation += GetBlockSubsidy(ActiveHeight(), Params().GetConsensus());
+                    assert(circulation <= (8'000'000 * COIN - 3'000'000 * COIN));
                 }
 
                 UpdateUtxoStats();

--- a/src/test/validation_tests.cpp
+++ b/src/test/validation_tests.cpp
@@ -28,16 +28,20 @@ static void TestBlockSubsidyHalvings(const Consensus::Params& consensusParams)
     int maxHalvings = 64;
     CAmount nInitialSubsidy = 50 * COIN;
 
-    CAmount nPreviousSubsidy = nInitialSubsidy * 2; // for height == 0
+    CAmount nPreviousSubsidy = nInitialSubsidy * 2; // for height == 1
     BOOST_CHECK_EQUAL(nPreviousSubsidy, nInitialSubsidy * 2);
     for (int nHalvings = 0; nHalvings < maxHalvings; nHalvings++) {
-        int nHeight = nHalvings * consensusParams.nSubsidyHalvingInterval;
+        int nHeight = 1 + nHalvings * consensusParams.nSubsidyHalvingInterval;
         CAmount nSubsidy = GetBlockSubsidy(nHeight, consensusParams);
         BOOST_CHECK(nSubsidy <= nInitialSubsidy);
-        BOOST_CHECK_EQUAL(nSubsidy, nPreviousSubsidy / 2);
+        if (nHalvings < 2) {
+            BOOST_CHECK_EQUAL(nSubsidy, nPreviousSubsidy / 2);
+        } else {
+            BOOST_CHECK_EQUAL(nSubsidy, 0);
+        }
         nPreviousSubsidy = nSubsidy;
     }
-    BOOST_CHECK_EQUAL(GetBlockSubsidy(maxHalvings * consensusParams.nSubsidyHalvingInterval, consensusParams), 0);
+    BOOST_CHECK_EQUAL(GetBlockSubsidy(1 + maxHalvings * consensusParams.nSubsidyHalvingInterval, consensusParams), 0);
 }
 
 static void TestBlockSubsidyHalvings(int nSubsidyHalvingInterval)
@@ -59,13 +63,13 @@ BOOST_AUTO_TEST_CASE(subsidy_limit_test)
 {
     const auto chainParams = CreateChainParams(*m_node.args, ChainType::MAIN);
     CAmount nSum = 0;
-    for (int nHeight = 0; nHeight < 14000000; nHeight += 1000) {
+    for (int nHeight = 1; nHeight < 14000000; nHeight += 1000) {
         CAmount nSubsidy = GetBlockSubsidy(nHeight, chainParams->GetConsensus());
         BOOST_CHECK(nSubsidy <= 50 * COIN);
         nSum += nSubsidy * 1000;
         BOOST_CHECK(MoneyRange(nSum));
     }
-    BOOST_CHECK_EQUAL(nSum, CAmount{899999999010000});
+    BOOST_CHECK_EQUAL(nSum, CAmount{500'000'000'000'000});
 }
 
 BOOST_AUTO_TEST_CASE(signet_parse_tests)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2176,21 +2176,33 @@ PackageMempoolAcceptResult ProcessNewPackage(Chainstate& active_chainstate, CTxM
 
 CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams)
 {
-    // Hard cap: 8M BGD total supply with 3M premine in genesis block.
-    // First 90k blocks reward 50, next 20k reward 25, then 0.
-    if (nHeight <= 0) return 0; // genesis handled separately
+    // Genesis premine handled separately
+    if (nHeight <= 0) return 0;
 
-    if (nHeight <= consensusParams.nSubsidyHalvingInterval) {
-        return 50 * COIN;
+    const CAmount max_subsidy{8'000'000 * COIN - 3'000'000 * COIN};
+
+    // Compute the current block subsidy with Bitcoin-like halving schedule
+    int halvings = (nHeight - 1) / consensusParams.nSubsidyHalvingInterval;
+    if (halvings >= 64) return 0;
+    CAmount subsidy = 50 * COIN;
+    subsidy >>= halvings;
+
+    // Calculate cumulative subsidy up to the previous block
+    CAmount minted{0};
+    int height = nHeight - 1;
+    CAmount current_subsidy = 50 * COIN;
+    while (height > 0 && current_subsidy > 0) {
+        int blocks = std::min(height, consensusParams.nSubsidyHalvingInterval);
+        minted += current_subsidy * blocks;
+        height -= blocks;
+        current_subsidy >>= 1;
     }
 
-    // Allow only 20k blocks at the halved reward before hitting the cap
-    const int second_phase = consensusParams.nSubsidyHalvingInterval + 20000;
-    if (nHeight <= second_phase) {
-        return 25 * COIN;
+    // Clamp subsidy to remaining supply
+    if (minted >= max_subsidy) {
+        return 0;
     }
-
-    return 0;
+    return std::min(subsidy, max_subsidy - minted);
 }
 
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast,


### PR DESCRIPTION
## Summary
- compute block subsidy using shifting halving schedule
- clamp subsidy when total minted reaches 5M BGD (after 3M genesis premine)
- adjust unit and fuzz tests for new subsidy logic

## Testing
- `cmake -S . -B build -DENABLE_BULLETPROOFS=OFF`
- `cmake --build build --target test_bitcoin` *(interrupted: build exceeded time constraints)*

------
https://chatgpt.com/codex/tasks/task_b_68c3100f874c832aa3026664bfad473f