### PR TITLE
Adjust maximum supply to 8 million

### DIFF
--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -113,7 +113,7 @@ public:
         consensus.posLimit = consensus.powLimit;
         consensus.posLimitLower = consensus.powLimit;
         consensus.nStakeTargetSpacing = 8 * 60;
-        consensus.nMaximumSupply = 21'000'000 * COIN;
+        consensus.nMaximumSupply = 8'000'000 * COIN;
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.enforce_BIP94 = false;
         consensus.fPowNoRetargeting = false;
@@ -247,7 +247,7 @@ public:
         consensus.posLimit = consensus.powLimit;
         consensus.posLimitLower = consensus.powLimit;
         consensus.nStakeTargetSpacing = 8 * 60;
-        consensus.nMaximumSupply = 21'000'000 * COIN;
+        consensus.nMaximumSupply = 8'000'000 * COIN;
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.enforce_BIP94 = false;
         consensus.fPowNoRetargeting = false;
@@ -404,7 +404,7 @@ public:
         consensus.posLimit = consensus.powLimit;
         consensus.posLimitLower = consensus.powLimit;
         consensus.nStakeTargetSpacing = 8 * 60;
-        consensus.nMaximumSupply = 21'000'000 * COIN;
+        consensus.nMaximumSupply = 8'000'000 * COIN;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
@@ -507,7 +507,7 @@ public:
         consensus.posLimit = consensus.powLimit;
         consensus.posLimitLower = consensus.powLimit;
         consensus.nStakeTargetSpacing = 8 * 60;
-        consensus.nMaximumSupply = 21'000'000 * COIN;
+        consensus.nMaximumSupply = 8'000'000 * COIN;
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.enforce_BIP94 = opts.enforce_bip94;
         consensus.fPowNoRetargeting = true;

--- a/src/test/compress_tests.cpp
+++ b/src/test/compress_tests.cpp
@@ -20,8 +20,8 @@
 // amounts 1 .. 10000
 #define NUM_MULTIPLES_1BTC 10000
 
-// amounts 50 .. 21000000
-#define NUM_MULTIPLES_50BTC 420000
+// amounts 50 .. 8000000
+#define NUM_MULTIPLES_50BTC 160000
 
 BOOST_FIXTURE_TEST_SUITE(compress_tests, BasicTestingSetup)
 
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_CASE(compress_amounts)
     BOOST_CHECK(TestPair(         CENT,       0x7));
     BOOST_CHECK(TestPair(         COIN,       0x9));
     BOOST_CHECK(TestPair(      50*COIN,      0x32));
-    BOOST_CHECK(TestPair(21000000*COIN, 0x1406f40));
+    BOOST_CHECK(TestPair( 8000000*COIN,    0x7a1200));
 
     for (uint64_t i = 1; i <= NUM_MULTIPLES_UNIT; i++)
         BOOST_CHECK(TestEncode(i));

--- a/src/test/feefrac_tests.cpp
+++ b/src/test/feefrac_tests.cpp
@@ -126,24 +126,24 @@ BOOST_AUTO_TEST_CASE(feefrac_operators)
     FeeFrac busted{(static_cast<int64_t>(INT32_MAX)) + 1, INT32_MAX};
     BOOST_CHECK(!(busted < busted));
 
-    FeeFrac max_fee{2100000000000000, INT32_MAX};
+    FeeFrac max_fee{800000000000000, INT32_MAX};
     BOOST_CHECK(!(max_fee < max_fee));
     BOOST_CHECK(!(max_fee > max_fee));
     BOOST_CHECK(max_fee <= max_fee);
     BOOST_CHECK(max_fee >= max_fee);
 
     BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(0), 0);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(1), 977888);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(2), 1955777);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(3), 2933666);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(1256796054), 1229006664189047);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(INT32_MAX), 2100000000000000);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(1), 372529);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(2), 745058);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(3), 1117587);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(1256796054), 468193014929160);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(INT32_MAX), 800000000000000);
     BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(0), 0);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(1), 977889);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(2), 1955778);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(3), 2933667);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(1256796054), 1229006664189048);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(INT32_MAX), 2100000000000000);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(1), 372530);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(2), 745059);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(3), 1117588);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(1256796054), 468193014929161);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(INT32_MAX), 800000000000000);
 
     FeeFrac max_fee2{1, 1};
     BOOST_CHECK(max_fee >= max_fee2);

--- a/src/test/util/cluster_linearize.h
+++ b/src/test/util/cluster_linearize.h
@@ -212,7 +212,7 @@ struct DepGraphFormatter
                 uint64_t coded_fee;
                 s >> VARINT(coded_fee);
                 coded_fee &= 0xFFFFFFFFFFFFF; // Enough for fee between -21M...21M BTC.
-                static_assert(0xFFFFFFFFFFFFF > uint64_t{2} * 21000000 * 100000000);
+                static_assert(0xFFFFFFFFFFFFF > uint64_t{2} * 8000000 * 100000000);
                 new_feerate = {UnsignedToSigned(coded_fee), size};
                 // Read dependency information.
                 auto topo_idx = reordering.size();

--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -400,7 +400,7 @@ class MempoolLimitTest(BitcoinTestFramework):
         self.log.info("Check a package that passes mempoolminfee but is evicted immediately after submission")
         mempoolmin_feerate = node.getmempoolinfo()["mempoolminfee"]
         current_mempool = node.getrawmempool(verbose=False)
-        worst_feerate_btcvb = Decimal("21000000")
+        worst_feerate_btcvb = Decimal("8000000")
         for txid in current_mempool:
             entry = node.getmempoolentry(txid)
             worst_feerate_btcvb = min(worst_feerate_btcvb, entry["fees"]["descendant"] / entry["descendantsize"])

--- a/test/functional/test_framework/compressor.py
+++ b/test/functional/test_framework/compressor.py
@@ -55,4 +55,4 @@ class TestFrameworkCompressor(unittest.TestCase):
         check_amount(1000000, 0x7)
         check_amount(COIN, 0x9)
         check_amount(50*COIN, 0x32)
-        check_amount(21000000*COIN, 0x1406f40)
+        check_amount(8000000*COIN, 0x7a1200)

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -39,7 +39,7 @@ MAX_BLOOM_FILTER_SIZE = 36000
 MAX_BLOOM_HASH_FUNCS = 50
 
 COIN = 100000000  # 1 btc in satoshis
-MAX_MONEY = 21000000 * COIN
+MAX_MONEY = 8000000 * COIN
 
 MAX_BIP125_RBF_SEQUENCE = 0xfffffffd  # Sequence number that is rbf-opt-in (BIP 125) and csv-opt-out (BIP 68)
 MAX_SEQUENCE_NONFINAL = 0xfffffffe  # Sequence number that is csv-opt-out (BIP 68)
@@ -685,7 +685,7 @@ class CTransaction:
 
     def is_valid(self):
         for tout in self.vout:
-            if tout.nValue < 0 or tout.nValue > 21000000 * COIN:
+            if tout.nValue < 0 or tout.nValue > 8000000 * COIN:
                 return False
         return True
 


### PR DESCRIPTION
## Summary
- Set the consensus `nMaximumSupply` for all networks to `8'000'000 * COIN`
- Align functional and unit tests with the new 8M coin cap

## Testing
- `python3 -m py_compile test/functional/test_framework/messages.py test/functional/test_framework/compressor.py test/functional/mempool_limit.py`
- `cmake --build build --target test_bitcoin` *(fails: interrupt)*

------
https://chatgpt.com/codex/tasks/task_b_68c3100b9124832aa172ce48e50ad382