### PR TITLE
Update testnet and signet Bech32 HRPs

### DIFF
--- a/doc/offline-signing-tutorial.md
+++ b/doc/offline-signing-tutorial.md
@@ -114,7 +114,7 @@ At this point, it's important to understand that both the `offline_wallet` and o
 ```sh
 [online]$ ./build/bin/bitcoin-cli -signet -rpcwallet="watch_only_wallet" getnewaddress
 
-tb1qtu5qgc6ddhmqm5yqjvhg83qgk2t4ewajg0h6yh
+sb1qtu5qgc6ddhmqm5yqjvhg83qgk2t4ewajg0h6yh
 ```
 
 2. Visit a faucet like https://signetfaucet.com and enter your address from the previous command to receive a small amount of signet coins to this address.
@@ -128,7 +128,7 @@ tb1qtu5qgc6ddhmqm5yqjvhg83qgk2t4ewajg0h6yh
   {
     "txid": "0f3953dfc3eb8e753cd1633151837c5b9953992914ff32b7de08c47f1f29c762",
     "vout": 1,
-    "address": "tb1qtu5qgc6ddhmqm5yqjvhg83qgk2t4ewajg0h6yh",
+    "address": "sb1qtu5qgc6ddhmqm5yqjvhg83qgk2t4ewajg0h6yh",
     "label": "",
     "scriptPubKey": "00145f2804634d6df60dd080932e83c408b2975cbbb2",
     "amount": 0.01000000,
@@ -146,13 +146,13 @@ tb1qtu5qgc6ddhmqm5yqjvhg83qgk2t4ewajg0h6yh
 
 ### Create and Export an Unsigned PSBT
 
-1. Get a destination address for the transaction. In this tutorial we'll be sending funds to the address `tb1q9k5w0nhnhyeh78snpxh0t5t7c3lxdeg3erez32`, but if you don't need the coins for further testing you could send the coins back to the faucet.
+1. Get a destination address for the transaction. In this tutorial we'll be sending funds to the address `sb1q9k5w0nhnhyeh78snpxh0t5t7c3lxdeg3erez32`, but if you don't need the coins for further testing you could send the coins back to the faucet.
 
 2. Create a funded but unsigned PSBT to the destination address with the online `watch_only_wallet` by using `send [{"address":amount},...]` and export the unsigned PSBT to a file `funded_psbt.txt` for easy portability to the `offline_wallet` for signing:
 
 ```sh
 [online]$ ./build/bin/bitcoin-cli -signet -rpcwallet="watch_only_wallet" send \
-              '{"tb1q9k5w0nhnhyeh78snpxh0t5t7c3lxdeg3erez32": 0.009}' \
+              '{"sb1q9k5w0nhnhyeh78snpxh0t5t7c3lxdeg3erez32": 0.009}' \
               | jq -r '.psbt' \
               >> /path/to/funded_psbt.txt
 

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -307,7 +307,7 @@ public:
         base58Prefixes[EXT_PUBLIC_KEY] = {0x02, 0x41, 0xC6, 0x5A}; // bgpub
         base58Prefixes[EXT_SECRET_KEY] = {0x02, 0x41, 0xB2, 0x1B}; // bgprv
 
-        bech32_hrp = "tbg";
+        bech32_hrp = "tb";
 
         vFixedSeeds = std::vector<uint8_t>(std::begin(chainparams_seed_test), std::end(chainparams_seed_test));
 
@@ -461,7 +461,7 @@ public:
         base58Prefixes[EXT_PUBLIC_KEY] = {0x02, 0x41, 0xC6, 0x5A}; // bgpub
         base58Prefixes[EXT_SECRET_KEY] = {0x02, 0x41, 0xB2, 0x1B}; // bgprv
 
-        bech32_hrp = "tbg";
+        bech32_hrp = "sb";
 
         fDefaultConsistencyChecks = false;
         m_is_mockable_chain = false;

--- a/src/test/data/key_io_valid.json
+++ b/src/test/data/key_io_valid.json
@@ -208,7 +208,7 @@
         }
     ],
     [
-        "tb1q3vya2h5435jkugq2few7dmktlrwq4ejmfaw7kr",
+        "sb1q3vya2h5435jkugq2few7dmktlrwq4ejmv69mku",
         "00148b09d55e958d256e200a4e5de6eecbf8dc0ae65b",
         {
             "chain": "signet",
@@ -217,7 +217,7 @@
         }
     ],
     [
-        "tb1qxkhrl2s6ttrclckldruea0e8anhrehffl8xv7t0pdyrzm08v2hyqy408nf",
+        "sb1qxkhrl2s6ttrclckldruea0e8anhrehffl8xv7t0pdyrzm08v2hyqry9q2v",
         "002035ae3faa1a5ac78fe2df68f99ebf27ecee3cdd29f9cccf2de169062dbcec55c8",
         {
             "chain": "signet",
@@ -226,7 +226,7 @@
         }
     ],
     [
-        "tb1pae5um27ahn8n73pgexe3kcwlp8dhswpn684h2k2w6t9a7w3eq65qephd5y",
+        "sb1pae5um27ahn8n73pgexe3kcwlp8dhswpn684h2k2w6t9a7w3eq65q7sa2dp",
         "5120ee69cdabddbccf3f4428c9b31b61df09db783833d1eb75594ed2cbdf3a3906a8",
         {
             "chain": "signet",
@@ -235,7 +235,7 @@
         }
     ],
     [
-        "tb1rx9n9g37az8mu236e5jpxdt0m67y4fuq8rhs0ss3djnm0kscfrwvq0ntlyg",
+        "sb1rx9n9g37az8mu236e5jpxdt0m67y4fuq8rhs0ss3djnm0kscfrwvqgzpcad",
         "532031665447dd11f7c54759a48266adfbd78954f0071de0f8422d94f6fb43091b98",
         {
             "chain": "signet",
@@ -488,7 +488,7 @@
         }
     ],
     [
-        "tb1q6mwf89hnqhlu8txjgjfs4s7p93ugffn3k062ll",
+        "sb1q6mwf89hnqhlu8txjgjfs4s7p93ugffn3ng30lq",
         "0014d6dc9396f305ffc3acd244930ac3c12c7884a671",
         {
             "chain": "signet",
@@ -497,7 +497,7 @@
         }
     ],
     [
-        "tb1qafrjalu4d73dql0czau9j6z422434kef235mzljf48ckd5xz3sys09jm97",
+        "sb1qafrjalu4d73dql0czau9j6z422434kef235mzljf48ckd5xz3sysg5cuum",
         "0020ea472eff956fa2d07df8177859685552ab1adb295469b17e49a9f166d0c28c09",
         {
             "chain": "signet",
@@ -506,7 +506,7 @@
         }
     ],
     [
-        "tb1pwst9qszjrhuv2e7as0flcq9gm698v6gdxzz9e87p07s8rssdx3zqklm3vf",
+        "sb1pwst9qszjrhuv2e7as0flcq9gm698v6gdxzz9e87p07s8rssdx3zq3w3k4v",
         "512074165040521df8c567dd83d3fc00a8de8a76690d30845c9fc17fa071c20d3444",
         {
             "chain": "signet",
@@ -515,7 +515,7 @@
         }
     ],
     [
-        "tb1r3ss76jtsuxe8c8c8lxsehnpak55ylrgr345pww076l536ahjr6jsydamx3",
+        "sb1r3ss76jtsuxe8c8c8lxsehnpak55ylrgr345pww076l536ahjr6jsruhul5",
         "53208c21ed4970e1b27c1f07f9a19bcc3db5284f8d038d681739fed7e91d76f21ea5",
         {
             "chain": "signet",

--- a/src/test/key_io_tests.cpp
+++ b/src/test/key_io_tests.cpp
@@ -8,6 +8,7 @@
 #include <key.h>
 #include <key_io.h>
 #include <script/script.h>
+#include <script/standard.h>
 #include <test/util/json.h>
 #include <test/util/setup_common.h>
 #include <univalue.h>
@@ -145,6 +146,22 @@ BOOST_AUTO_TEST_CASE(key_io_invalid)
             BOOST_CHECK_MESSAGE(!privkey.IsValid(), "IsValid privkey in mainnet:" + strTest);
         }
     }
+}
+
+BOOST_AUTO_TEST_CASE(bech32_hrp_networks)
+{
+    CKey key;
+    key.MakeNewKey(true);
+
+    SelectParams(ChainType::TESTNET);
+    auto dest = WitnessV0KeyHash(key.GetPubKey().GetID());
+    BOOST_CHECK(EncodeDestination(dest).starts_with("tb1"));
+
+    SelectParams(ChainType::SIGNET);
+    dest = WitnessV0KeyHash(key.GetPubKey().GetID());
+    BOOST_CHECK(EncodeDestination(dest).starts_with("sb1"));
+
+    SelectParams(ChainType::MAIN);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/functional/wallet_bech32_hrps.py
+++ b/test/functional/wallet_bech32_hrps.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Verify bech32 HRPs on testnet and signet."""
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+class Bech32HRPTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.setup_clean_chain = True
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def setup_network(self):
+        self.add_nodes(self.num_nodes)
+        # Configure node0 for testnet
+        self.nodes[0].chain = 'testnet4'
+        self.nodes[0].replace_in_config([('regtest=', 'testnet4='), ('[regtest]', '[testnet4]')])
+        self.nodes[0].extra_args = ['-maxconnections=0']
+        # Configure node1 for signet
+        self.nodes[1].chain = 'signet'
+        self.nodes[1].replace_in_config([('regtest=', 'signet='), ('[regtest]', '[signet]')])
+        self.nodes[1].extra_args = ['-maxconnections=0']
+        self.start_nodes()
+
+    def run_test(self):
+        self.log.info("Check Bech32 HRPs for testnet and signet")
+        tb_addr = self.nodes[0].getnewaddress(address_type='bech32')
+        assert_equal(tb_addr[:2], 'tb')
+        sb_addr = self.nodes[1].getnewaddress(address_type='bech32')
+        assert_equal(sb_addr[:2], 'sb')
+
+if __name__ == '__main__':
+    Bech32HRPTest(__file__).main()


### PR DESCRIPTION
## Summary
- set testnet Bech32 HRP to `tb` and signet to `sb`
- update address fixtures and docs for new prefixes
- add unit and functional tests to confirm testnet/signet HRPs

## Testing
- `test/functional/test_runner.py wallet_bech32_hrps.py --jobs=1` *(fails: No functional tests to run. Re-compile with the -DBUILD_DAEMON=ON build option)*
- `ninja -C build check` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68c32e66bfd8832aa5ace73396370a7b