### PR TITLE
Increase stake minimum age to eight hours

### DIFF
--- a/doc/pos31_audit.md
+++ b/doc/pos31_audit.md
@@ -12,7 +12,7 @@ The repository already contains a sizeable PoS implementation:
   * `ContextualCheckProofOfStake` (coinstake structure, coin age, timestamp/slot rules)
   * `CheckStakeTimestamp` helper enforcing the 16‑second mask and tight future drift
   * `IsProofOfStake` utility
-  * constant `MIN_STAKE_AGE` (1h); target spacing is configured via consensus parameter `nStakeTargetSpacing`
+  * constant `MIN_STAKE_AGE` (8h); target spacing is configured via consensus parameter `nStakeTargetSpacing`
   * minimum stake age, coinstake format, difficulty retargeting, and block signature validation are enforced during block checks
 * **Stake modifier handling** – `src/pos/stakemodifier.cpp` and `src/pos/stakemodifier_manager.cpp` provide modifier computation and a manager refreshing it at fixed intervals.
 * **Difficulty retargeting** – `src/pos/difficulty.cpp` supplies a PoS retarget routine used by `GetNextWorkRequired`.

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -131,7 +131,7 @@ struct Params {
     // Timestamp mask for staked blocks (seconds)
     uint32_t nStakeTimestampMask{0xF};
     // Minimum coin age required for staking (seconds)
-    int64_t nStakeMinAge{60 * 60};
+    int64_t nStakeMinAge{8 * 60 * 60};
     // Interval between stake modifier recalculations (seconds)
     int64_t nStakeModifierInterval{60 * 60};
     // Version of stake modifier algorithm (0=legacy, 1=interval-based)

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -106,7 +106,7 @@ public:
         consensus.posActivationHeight = 2;
         consensus.fEnablePoS = true; // Enable PoS from genesis except premine block
         consensus.nStakeTimestampMask = 0xF;
-        consensus.nStakeMinAge = 60 * 60;
+        consensus.nStakeMinAge = 8 * 60 * 60;
         consensus.nStakeModifierInterval = 60 * 60;
         consensus.nStakeModifierVersion = 1;
         consensus.nStakeMinConfirmations = 80;
@@ -246,7 +246,7 @@ public:
         consensus.posActivationHeight = 2;
         consensus.fEnablePoS = true; // Enable PoS in testnet
         consensus.nStakeTimestampMask = 0xF;
-        consensus.nStakeMinAge = 60 * 60;
+        consensus.nStakeMinAge = 8 * 60 * 60;
         consensus.nStakeModifierInterval = 60 * 60;
         consensus.nStakeModifierVersion = 1;
         consensus.nStakeMinConfirmations = 80;
@@ -394,7 +394,7 @@ public:
         consensus.posActivationHeight = 2;
         consensus.fEnablePoS = true; // Enable PoS on signet
         consensus.nStakeTimestampMask = 0xF;
-        consensus.nStakeMinAge = 60 * 60;
+        consensus.nStakeMinAge = 8 * 60 * 60;
         consensus.nStakeModifierInterval = 60 * 60;
         consensus.nStakeModifierVersion = 1;
         consensus.nStakeMinConfirmations = 80;
@@ -497,7 +497,7 @@ public:
         consensus.posActivationHeight = opts.pos_activation_height;
         consensus.fEnablePoS = true;
         consensus.nStakeTimestampMask = 0xF;
-        consensus.nStakeMinAge = 60 * 60;
+        consensus.nStakeMinAge = 8 * 60 * 60;
         consensus.nStakeModifierInterval = 60 * 60;
         consensus.nStakeModifierVersion = 1;
         consensus.nStakeMinConfirmations = 80;

--- a/src/pos/stake.h
+++ b/src/pos/stake.h
@@ -13,9 +13,9 @@ class CBlockIndex;
 
 // Default timestamp granularity for staked blocks (16 seconds, PoSV3.1)
 static constexpr unsigned int STAKE_TIMESTAMP_MASK = 0xF;
-// Default minimum coin age for staking (1 hour, PoSV3.1)
+// Default minimum coin age for staking (8 hours, PoSV3.1)
 // Network-specific values are provided via consensus parameters
-static constexpr int64_t MIN_STAKE_AGE = 60 * 60;
+static constexpr int64_t MIN_STAKE_AGE = 8 * 60 * 60;
 
 /** Check that the kernel for a stake meets the required target */
 bool CheckStakeKernelHash(const CBlockIndex* pindexPrev, unsigned int nBits,

--- a/src/wallet/bitgoldstaker.cpp
+++ b/src/wallet/bitgoldstaker.cpp
@@ -58,7 +58,6 @@ void BitGoldStaker::ThreadStakeMiner()
     const Consensus::Params& consensus = chainman.GetParams().GetConsensus();
     const CAmount MIN_STAKE_AMOUNT{1 * COIN};
     const int MIN_STAKE_DEPTH{COINBASE_MATURITY};
-    const std::chrono::seconds MIN_COIN_AGE{std::chrono::hours(1)};
 
     std::chrono::milliseconds sleep_time{500};
     while (!m_stop) {
@@ -71,7 +70,8 @@ void BitGoldStaker::ThreadStakeMiner()
             }
             const int min_depth = chain_height < MIN_STAKE_DEPTH ? 0 : MIN_STAKE_DEPTH;
             const std::chrono::seconds min_age =
-                chain_height < MIN_STAKE_DEPTH ? std::chrono::seconds{0} : MIN_COIN_AGE;
+                chain_height < MIN_STAKE_DEPTH ? std::chrono::seconds{0}
+                                               : std::chrono::seconds{consensus.nStakeMinAge};
 
             std::vector<COutput> candidates = m_wallet.GetStakeableCoins(min_depth, min_age, MIN_STAKE_AMOUNT);
 

--- a/test/functional/pos_activation.py
+++ b/test/functional/pos_activation.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Test PoS activation stake-age requirements and reorg handling."""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.blocktools import create_block, create_coinbase
+from test_framework.messages import (
+    CTransaction,
+    CTxIn,
+    CTxOut,
+    COutPoint,
+    COIN,
+    hash256,
+    uint256_from_compact,
+)
+from test_framework.script import CScript
+from test_framework.util import assert_equal
+
+STAKE_TIMESTAMP_MASK = 0xF
+MIN_STAKE_AGE = 8 * 60 * 60
+
+
+def check_kernel(prev_hash, prev_height, prev_time, nbits, stake_hash, stake_time, amount, prevout, ntime):
+    if ntime & STAKE_TIMESTAMP_MASK:
+        return False
+    if ntime <= stake_time or ntime - stake_time < MIN_STAKE_AGE:
+        return False
+    stake_modifier = hash256(
+        bytes.fromhex(prev_hash)[::-1]
+        + prev_height.to_bytes(4, "little")
+        + prev_time.to_bytes(4, "little")
+    )
+    ntime_masked = ntime & ~STAKE_TIMESTAMP_MASK
+    stake_time_masked = stake_time & ~STAKE_TIMESTAMP_MASK
+    data = (
+        stake_modifier
+        + bytes.fromhex(stake_hash)[::-1]
+        + stake_time_masked.to_bytes(4, "little")
+        + bytes.fromhex(prevout["txid"])[::-1]
+        + prevout["vout"].to_bytes(4, "little")
+        + ntime_masked.to_bytes(4, "little")
+    )
+    proof = hash256(data)
+    target = uint256_from_compact(nbits) * (amount // COIN)
+    return int.from_bytes(proof[::-1], "big") <= target
+
+
+def stake_block(node):
+    unspent = node.listunspent()[0]
+    txid = unspent["txid"]
+    vout = unspent["vout"]
+    amount = int(unspent["amount"] * COIN)
+    prevout = {"txid": txid, "vout": vout}
+
+    prev_height = node.getblockcount()
+    prev_hash = node.getbestblockhash()
+    prev_block = node.getblock(prev_hash)
+    nbits = int(prev_block["bits"], 16)
+    prev_time = prev_block["time"]
+
+    stake_block_hash = node.gettransaction(txid)["blockhash"]
+    stake_time = node.getblock(stake_block_hash)["time"]
+
+    ntime = max(prev_time + 16, stake_time + MIN_STAKE_AGE)
+    while not check_kernel(
+        prev_hash,
+        prev_height,
+        prev_time,
+        nbits,
+        stake_block_hash,
+        stake_time,
+        amount,
+        prevout,
+        ntime,
+    ):
+        ntime += 16
+
+    script = CScript(bytes.fromhex(unspent["scriptPubKey"]))
+    coinstake = CTransaction()
+    coinstake.nLockTime = ntime
+    coinstake.vin.append(CTxIn(COutPoint(int(txid, 16), vout)))
+    coinstake.vout.append(CTxOut(0, CScript()))
+    reward = 50 * COIN
+    coinstake.vout.append(CTxOut(amount + reward, script))
+    signed_hex = node.signrawtransactionwithwallet(coinstake.serialize().hex())["hex"]
+    coinstake = CTransaction()
+    coinstake.deserialize(bytes.fromhex(signed_hex))
+
+    coinbase = create_coinbase(prev_height + 1, nValue=0)
+    block = create_block(
+        int(prev_hash, 16),
+        coinbase,
+        ntime,
+        tmpl={"bits": prev_block["bits"], "height": prev_height + 1},
+        txlist=[coinstake],
+    )
+    block.hashMerkleRoot = block.calc_merkle_root()
+    node.submitblock(block.serialize().hex())
+    assert_equal(node.getblockcount(), prev_height + 1)
+
+
+class PosActivationTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.extra_args = [["-posactivationheight=200"], ["-posactivationheight=200"]]
+
+    def setup_network(self):
+        self.setup_nodes()
+        self.connect_nodes(0, 1)
+
+    def run_test(self):
+        node0, node1 = self.nodes
+        addr = node0.getnewaddress()
+        node0.generatetoaddress(200, addr)
+        self.sync_all()
+
+        # Share staking key with node1
+        node1.importprivkey(node0.dumpprivkey(addr))
+
+        # Check that age below minimum is rejected
+        unspent = node0.listunspent()[0]
+        txid = unspent["txid"]
+        prev_hash = node0.getbestblockhash()
+        prev_block = node0.getblock(prev_hash)
+        prev_height = prev_block["height"]
+        prev_time = prev_block["time"]
+        nbits = int(prev_block["bits"], 16)
+        stake_block_hash = node0.gettransaction(txid)["blockhash"]
+        stake_time = node0.getblock(stake_block_hash)["time"]
+        amount = int(unspent["amount"] * COIN)
+        prevout = {"txid": txid, "vout": unspent["vout"]}
+        ntime = stake_time + MIN_STAKE_AGE - 16
+        assert not check_kernel(
+            prev_hash,
+            prev_height,
+            prev_time,
+            nbits,
+            stake_block_hash,
+            stake_time,
+            amount,
+            prevout,
+            ntime,
+        )
+
+        # Reorg scenario: stake competing chains
+        self.disconnect_nodes(0, 1)
+        stake_block(node0)
+        stake_block(node1)
+        stake_block(node1)
+        self.connect_nodes(0, 1)
+        self.sync_blocks()
+        expected_height = prev_height + 2
+        assert_equal(node0.getblockcount(), expected_height)
+        assert_equal(node0.getbestblockhash(), node1.getbestblockhash())
+
+
+if __name__ == "__main__":
+    PosActivationTest(__file__).main()


### PR DESCRIPTION
## Summary
- raise staking minimum age to eight hours across consensus and chain parameters
- have wallet staking reference consensus minimum age
- add functional test for stake-age edge cases and reorg behavior

## Testing
- `python3 test/functional/pos_activation.py --configfile=test/config.ini` *(fails: No such file or directory: '/workspace/bitcoin/bin/bitcoind')*
- `./src/test/test_bitcoin` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68c33be56ffc832ab78be034bf208f58