### PR TITLE
docs: add whitepaper lite and usage guides

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -91,6 +91,9 @@ The Bitcoin repo's [root README](/README.md) contains relevant information on th
 - [ZMQ](zmq.md)
 - [Staking](staking.md)
 - [Bulletproofs](bulletproofs.md)
+- [Whitepaper Lite](whitepaper-lite.md)
+- [Operator Guide](operator-guide.md)
+- [Wallet Guide](wallet-guide.md)
 
 License
 ---------------------

--- a/doc/operator-guide.md
+++ b/doc/operator-guide.md
@@ -1,0 +1,24 @@
+# BitGold Operator Guide
+
+This guide outlines the basic steps for deploying and maintaining BitGold infrastructure.
+
+## Node Setup
+
+1. **Install** the `bitgoldd` daemon and utilities from official releases.
+2. **Configure** `bitgold.conf` with your desired network, staking, and RPC settings.
+3. **Open Ports** 9888/TCP and 9888/UDP on your firewall to allow peer connections.
+4. **Run** `bitgoldd` as a system service and verify it begins synchronizing with the network.
+
+## Staking
+
+Enable staking by setting `staking=1` in `bitgold.conf` and unlocking your wallet for staking with `walletpassphrase <pass> 0 true`. Monitor staking status via `getstakinginfo`.
+
+## Monitoring
+
+Use the `getnetworkinfo`, `getstakinginfo`, and `getblockchaininfo` RPC commands to monitor node health. For production deployments integrate with external monitoring systems to track resource usage and network connectivity.
+
+## Upgrades
+
+Stay current with new releases. Stop the daemon, install the update, and restart. For minimal downtime consider running redundant nodes and updating them in sequence.
+
+For more advanced configurations consult the documentation in the `doc` directory and the community wiki.

--- a/doc/wallet-guide.md
+++ b/doc/wallet-guide.md
@@ -1,0 +1,30 @@
+# BitGold Wallet Guide
+
+This guide describes how to create and use a BitGold wallet for everyday transactions and staking.
+
+## Creating a Wallet
+
+1. Launch `bitgold-qt` or run `bitgold-cli createwallet <name>`.
+2. Back up the generated seed or wallet file to a secure location.
+
+## Sending and Receiving
+
+- Use the **Receive** tab or `getnewaddress` to obtain a BGD address.
+- Send coins with the **Send** tab or `sendtoaddress <addr> <amount>`.
+- Review activity with the **Transactions** tab or `listtransactions`.
+
+## Staking From the Wallet
+
+Unlock the wallet for staking only using `walletpassphrase <pass> 0 true`. The wallet will automatically participate in PoS once synchronized and funded.
+
+## Dividend Claims
+
+Dividends mature into claimable outputs. Use `claimdividends` (GUI: **Claim** button) to sweep matured dividends into your balance.
+
+## Security Best Practices
+
+- Encrypt your wallet with a strong passphrase.
+- Keep backups offline.
+- Verify download signatures before installing software updates.
+
+For more detailed usage examples refer to the command line help (`bitgold-cli help`) and the community wiki.

--- a/doc/whitepaper-lite.md
+++ b/doc/whitepaper-lite.md
@@ -1,0 +1,17 @@
+# BitGold Whitepaper Lite
+
+This document provides a high-level overview of BitGold's protocol design. It is intended as a concise reference describing the core mechanisms that govern consensus, incentives, and transaction processing.
+
+## Proof of Stake
+
+BitGold secures the network through a proof-of-stake (PoS) consensus algorithm. Participants lock BGD coins in staking outputs and take turns creating blocks proportionally to the amount staked. This design reduces energy consumption compared to proof-of-work while maintaining decentralized security. Stakeholders who help secure the network collect staking rewards and transaction fees.
+
+## Dividend Policy
+
+In addition to staking rewards, BitGold distributes a dividend from block subsidies to long‑term holders. Dividend outputs mature after a fixed holding period and can be claimed using standard wallet software. This mechanism incentivizes saving and broad participation in the network.
+
+## Priority Policy
+
+Transactions are prioritized according to a mempool policy that weighs fee rate, coin age, and dividend eligibility. High‑priority transactions are relayed and mined first, while low‑priority transactions may be deferred during congestion. Operators can tune policy parameters to balance fairness and network throughput.
+
+For the full protocol specification, refer to the complete whitepaper and accompanying technical documentation.


### PR DESCRIPTION
## Summary
- outline PoS, dividend, and priority policy in a new whitepaper-lite
- add operator and wallet guides for running nodes and managing funds
- link new documentation from the doc index

## Testing
- `python3 test/lint/check-doc.py doc/whitepaper-lite.md doc/operator-guide.md doc/wallet-guide.md doc/README.md` *(fails: Please add {'-reservebalance'} to the hidden args in DummyWalletInit::AddWalletOptions)*
- `python3 test/lint/lint-spelling.py doc/whitepaper-lite.md doc/operator-guide.md doc/wallet-guide.md doc/README.md` *(skipped: codespell not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68c33bf0e7f0832aadbcac23df210e3c