### PR TITLE
doc: note default block and mempool limits

### DIFF
--- a/doc/bitcoin-conf.md
+++ b/doc/bitcoin-conf.md
@@ -8,6 +8,9 @@ Changes to the configuration file while `bitcoind` or `bitcoin-qt` is running on
 
 Users should never make any configuration changes which they do not understand. Furthermore, users should always be wary of accepting any configuration changes provided to them by another source (even if they believe that they do understand them).
 
+By default the node limits blocks to 20 MWU, 100,000 signature operations, and a mempool of 500 MB (or 8 MB with `-blocksonly`). See [operating-notes.md](operating-notes.md) for details.
+
+
 ## Configuration File Precedence
 
 Options specified in the configuration file can be overridden by options in the [`settings.json` file](files.md) and by options specified on the command line.

--- a/doc/examples/network.conf
+++ b/doc/examples/network.conf
@@ -12,3 +12,5 @@ maxconnections=64
 
 # Enable listen for inbound connections
 listen=1
+
+# Default limits: 20 MWU blocks, 100k sigops, mempool 500 MB (8 MB with -blocksonly). See doc/operating-notes.md.

--- a/doc/examples/staking.conf
+++ b/doc/examples/staking.conf
@@ -8,3 +8,5 @@ reservebalance=100
 
 # Limit the number of coinstake attempts per second
 stakethreadlimit=4
+
+# Default limits: 20 MWU blocks, 100k sigops, mempool 500 MB (8 MB with -blocksonly). See doc/operating-notes.md.

--- a/doc/operating-notes.md
+++ b/doc/operating-notes.md
@@ -1,0 +1,9 @@
+# Operating Notes
+
+This document summarizes default limits enforced by the node.
+
+- **Block size**: Up to 20&nbsp;MWU (20 million weight units) per block.
+- **Signature operations**: Up to 100,000 sigops per block.
+- **Mempool size**: Defaults to 500&nbsp;MB for normal operation. When running with `-blocksonly`, the mempool is limited to 8&nbsp;MB.
+
+These limits are reflected in the sample configuration files and operator guidance. See [`doc/bitcoin-conf.md`](bitcoin-conf.md) and the example configs in [`doc/examples`](examples) for details.

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -1,0 +1,3 @@
+# Release Notes
+
+- Documented node limits: 20&nbsp;MWU block weight, 100,000 sigops per block, and mempool defaults of 500&nbsp;MB (or 8&nbsp;MB when run with `-blocksonly`). See [`doc/operating-notes.md`](operating-notes.md) for details and cross-references in configuration templates.

--- a/share/examples/bitcoin.conf
+++ b/share/examples/bitcoin.conf
@@ -1,1 +1,3 @@
 # This is a placeholder file. Please follow the instructions in `contrib/devtools/README.md` to generate a bitcoin.conf file.
+
+# Default limits: 20 MWU blocks, 100k sigops, mempool 500 MB (8 MB with -blocksonly). See doc/operating-notes.md.

--- a/src/dummywallet.cpp
+++ b/src/dummywallet.cpp
@@ -39,6 +39,7 @@ void DummyWalletInit::AddWalletOptions(ArgsManager& argsman) const
         "-maxtxfee=<amt>",
         "-mintxfee=<amt>",
         "-paytxfee=<amt>",
+        "-reservebalance=<amt>",
         "-signer=<cmd>",
         "-spendzeroconfchange",
         "-staker",


### PR DESCRIPTION
## Summary
- Document 20 MWU block weight, 100k sigops, and mempool defaults in operating notes
- Mention these limits in release notes and configuration examples
- Hide `-reservebalance` option in dummy wallet to satisfy doc lint

## Testing
- `cargo run -- --lint=doc` 
- `cargo run -- --lint=trailing_whitespace` *(fails: trailing whitespace in unrelated files)*
- `python3 test/lint/lint-files.py doc/operating-notes.md doc/release-notes.md doc/bitcoin-conf.md doc/examples/network.conf doc/examples/staking.conf share/examples/bitcoin.conf src/dummywallet.cpp` *(fails: shebang permission checks in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68c33be95e74832a945e691cd039fe85