### PR TITLE
build: centralize bulletproof option

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,7 +7,6 @@ include(AddWindowsResources)
 configure_file(${PROJECT_SOURCE_DIR}/cmake/bitcoin-build-config.h.in bitcoin-build-config.h USE_SOURCE_PERMISSIONS @ONLY)
 include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 
-option(ENABLE_BULLETPROOFS "Build with Bulletproofs support" ON)
 if(ENABLE_BULLETPROOFS)
   find_package(PkgConfig)
   if(NOT PkgConfig_FOUND)


### PR DESCRIPTION
## Summary
- remove duplicate ENABLE_BULLETPROOFS option from src/CMakeLists
- rely on top-level ENABLE_BULLETPROOFS option to drive bulletproof library linking

## Testing
- `cmake -S . -B build` *(fails: libsecp256k1_zkp missing)*
- `cmake -S . -B build -DENABLE_BULLETPROOFS=OFF`

------
https://chatgpt.com/codex/tasks/task_b_68c349648f80832ab19b0c9384c2836a