### PR TITLE
doc: replace bitcoin-cli references with bitgold-cli

### DIFF
--- a/doc/bitgoldstaking.md
+++ b/doc/bitgoldstaking.md
@@ -1,6 +1,6 @@
 # BitGold Staking
 
-Bitcoin Core includes an experimental proof-of-stake staker that can create
+BitGold Core includes an experimental proof-of-stake staker that can create
 blocks from mature wallet coins. The current implementation follows the
 PoSV3 (Proof-of-Stake Version 3) rules.
 
@@ -19,7 +19,7 @@ These rules are enforced automatically when staking is enabled.
 
 ## Enabling
 
-Start the node with `-staking=1` (or add `staking=1` to `bitcoin.conf`) to run
+Start the node with `-staking=1` (or add `staking=1` to `bitgold.conf`) to run
 the staking thread. The legacy `-staker` flag is also accepted. No additional
 configuration is required for PoSV3, but `-debug=staking` may be useful for
 troubleshooting.
@@ -29,7 +29,7 @@ troubleshooting.
 Use the `stakerstatus` RPC to check if staking is enabled and running:
 
 ```
-$ bitcoin-cli stakerstatus
+$ bitgold-cli stakerstatus
 {
   "enabled": true,
   "staking": true

--- a/doc/staking.md
+++ b/doc/staking.md
@@ -65,7 +65,7 @@ spending key offline. To create a cold‑stake address:
 2. On either system, call:
 
    ```
-   bitcoin-cli delegatestakeaddress "OWNER_ADDR" "STAKER_ADDR"
+   bitgold-cli delegatestakeaddress "OWNER_ADDR" "STAKER_ADDR"
    ```
 
    This returns a P2SH address and redeem script. Send coins to the returned
@@ -73,7 +73,7 @@ spending key offline. To create a cold‑stake address:
 3. On the staking node, register the address:
 
    ```
-   bitcoin-cli registercoldstakeaddress "DELEGATE_ADDR" "REDEEM_SCRIPT"
+   bitgold-cli registercoldstakeaddress "DELEGATE_ADDR" "REDEEM_SCRIPT"
    ```
 
    The staking thread will now include the delegated coins when attempting to


### PR DESCRIPTION
## Summary
- rename bitcoin-cli to bitgold-cli in staking documentation
- ensure staking docs consistently use BitGold terminology

## Testing
- `python3 test/lint/check-doc.py doc/staking.md doc/bitgoldstaking.md`
- `python3 test/lint/lint-files.py doc/staking.md doc/bitgoldstaking.md` *(fails: file permission errors in unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_b_68c3499faa58832aa24dbb81db1071e8