### PR TITLE
Add Bulletproof proof fuzzing and rejection tests

### DIFF
--- a/src/test/fuzz/CMakeLists.txt
+++ b/src/test/fuzz/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(fuzz
   blockfilter.cpp
   bloom_filter.cpp
   buffered_file.cpp
+  bulletproof_parse.cpp
   chain.cpp
   checkqueue.cpp
   cluster_linearize.cpp

--- a/src/test/fuzz/bulletproof_parse.cpp
+++ b/src/test/fuzz/bulletproof_parse.cpp
@@ -1,0 +1,32 @@
+#include <bulletproofs.h>
+#include <streams.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+
+FUZZ_TARGET(bulletproof_parse)
+{
+    FuzzedDataProvider fdp{buffer.data(), buffer.size()};
+#ifdef ENABLE_BULLETPROOFS
+    CBulletproof bp;
+    const auto commit = fdp.ConsumeBytes<unsigned char>(33);
+    if (commit.size() == 33) {
+        std::memcpy(bp.commitment.data, commit.data(), 33);
+    }
+    const size_t proof_size = fdp.ConsumeIntegralInRange<size_t>(0, 2 * SECP256K1_RANGE_PROOF_MAX_LENGTH);
+    bp.proof = fdp.ConsumeBytes<unsigned char>(proof_size);
+    const size_t extra_size = fdp.ConsumeIntegralInRange<size_t>(0, 1024);
+    bp.extra = fdp.ConsumeBytes<unsigned char>(extra_size);
+
+    DataStream ds{};
+    try {
+        ds << bp;
+        CBulletproof decoded;
+        ds >> decoded;
+        (void)VerifyBulletproof(decoded);
+    } catch (const std::ios_base::failure&) {
+        return;
+    }
+#else
+    (void)fdp;
+#endif
+}

--- a/test/functional/feature_bulletproof_invalid.py
+++ b/test/functional/feature_bulletproof_invalid.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Test that invalid Bulletproof proofs are rejected with proper errors."""
+
+from test_framework.authproxy import JSONRPCException
+from test_framework.messages import tx_from_hex
+from test_framework.script import CScript, CScriptOp
+from test_framework.test_framework import BitcoinTestFramework, SkipTest
+from test_framework.util import assert_equal
+
+
+class BulletproofInvalidTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+
+    def run_test(self):
+        node = self.nodes[0]
+        try:
+            created = node.createrawbulletprooftransaction([], {"data": "00"})
+        except JSONRPCException:
+            raise SkipTest("Bulletproof RPC not available")
+
+        tx = tx_from_hex(created["hex"])
+        elems = list(CScript(tx.vout[0].scriptPubKey))
+        commitment = elems[1]
+
+        # Empty proof -> bad-bulletproof
+        tx.vout[0].scriptPubKey = CScript([CScriptOp(0xbb), commitment, b""])
+        tx.rehash()
+        res = node.testmempoolaccept([tx.serialize().hex()])[0]
+        assert_equal(res["reject-reason"], "bad-bulletproof")
+
+        # Missing Bulletproof data -> bad-bulletproof-missing
+        tx2 = tx_from_hex(created["hex"])
+        tx2.vout[0].scriptPubKey = CScript([])
+        tx2.rehash()
+        res2 = node.testmempoolaccept([tx2.serialize().hex()])[0]
+        assert_equal(res2["reject-reason"], "bad-bulletproof-missing")
+
+
+if __name__ == '__main__':
+    BulletproofInvalidTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -166,6 +166,7 @@ BASE_SCRIPTS = [
     'rpc_validateaddress.py',
     'interface_bitcoin_cli.py',
     'feature_bind_extra.py',
+    'feature_bulletproof_invalid.py',
     'mempool_resurrect.py',
     'wallet_txn_doublespend.py --mineblock',
     'tool_bitcoin_chainstate.py',


### PR DESCRIPTION
## Summary
- fuzz Bulletproof parsing of commitments, proofs, and extra data
- test node rejection of malformed or missing Bulletproof proofs
- hook new test and fuzzer into existing test harnesses

## Testing
- `./configure -B build -DENABLE_BULLETPROOFS=OFF -DENABLE_FUZZ_BINARY=ON` *(success)*
- `cmake --build build --target bitcoind` *(fails: script/standard.h: No such file or directory)*
- `./test/functional/test_runner.py feature_bulletproof_invalid.py` *(fails: No such file or directory: config.ini)*

------
https://chatgpt.com/codex/tasks/task_b_68c3514ceff4832a868a9b7fdb3a5ce4