### PR TITLE
Parameterize genesis block reward

### DIFF
--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -10,6 +10,7 @@
 
 #include <array>
 #include <chrono>
+#include <consensus/amount.h>
 #include <limits>
 #include <map>
 #include <vector>
@@ -147,7 +148,9 @@ struct Params {
     // Target spacing between staked blocks (seconds)
     int64_t nStakeTargetSpacing{8 * 60};
     // Maximum allowed coin supply (satoshis)
-    uint64_t nMaximumSupply{0};
+    CAmount nMaximumSupply{0};
+    // Reward paid in the genesis block (satoshis)
+    CAmount genesis_reward{0};
     /** The best chain should have at least this much work */
     uint256 nMinimumChainWork;
     /** By default assume that the signatures in ancestors of this block are valid */

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -115,6 +115,7 @@ public:
         consensus.posLimitLower = consensus.powLimit;
         consensus.nStakeTargetSpacing = 8 * 60;
         consensus.nMaximumSupply = 8'000'000 * COIN;
+        consensus.genesis_reward = 3'000'000 * COIN;
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.enforce_BIP94 = false;
         consensus.fPowNoRetargeting = false;
@@ -257,6 +258,7 @@ public:
         consensus.posLimitLower = consensus.powLimit;
         consensus.nStakeTargetSpacing = 8 * 60;
         consensus.nMaximumSupply = 8'000'000 * COIN;
+        consensus.genesis_reward = 3'000'000 * COIN;
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.enforce_BIP94 = false;
         consensus.fPowNoRetargeting = false;
@@ -376,6 +378,7 @@ public:
         consensus.posLimitLower = consensus.powLimit;
         consensus.nStakeTargetSpacing = 8 * 60;
         consensus.nMaximumSupply = 8'000'000 * COIN;
+        consensus.genesis_reward = 3'000'000 * COIN;
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.enforce_BIP94 = true;
         consensus.fPowNoRetargeting = false;
@@ -541,6 +544,7 @@ public:
         consensus.posLimitLower = consensus.powLimit;
         consensus.nStakeTargetSpacing = 8 * 60;
         consensus.nMaximumSupply = 8'000'000 * COIN;
+        consensus.genesis_reward = 3'000'000 * COIN;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
@@ -640,6 +644,7 @@ public:
         consensus.posLimitLower = consensus.powLimit;
         consensus.nStakeTargetSpacing = 8 * 60;
         consensus.nMaximumSupply = 8'000'000 * COIN;
+        consensus.genesis_reward = 3'000'000 * COIN;
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.enforce_BIP94 = opts.enforce_bip94;
         consensus.fPowNoRetargeting = true;

--- a/src/test/validation_tests.cpp
+++ b/src/test/validation_tests.cpp
@@ -16,6 +16,7 @@
 #include <script/script.h>
 
 #include <string>
+#include <limits>
 
 #include <test/util/setup_common.h>
 
@@ -28,10 +29,10 @@ static void TestBlockSubsidyHalvings(const Consensus::Params& consensusParams)
     int maxHalvings = 64;
     CAmount nInitialSubsidy = 50 * COIN;
 
-    CAmount nPreviousSubsidy = nInitialSubsidy * 2; // for height == 1
+    CAmount nPreviousSubsidy = nInitialSubsidy * 2; // for height == 2
     BOOST_CHECK_EQUAL(nPreviousSubsidy, nInitialSubsidy * 2);
     for (int nHalvings = 0; nHalvings < maxHalvings; nHalvings++) {
-        int nHeight = 1 + nHalvings * consensusParams.nSubsidyHalvingInterval;
+        int nHeight = 2 + nHalvings * consensusParams.nSubsidyHalvingInterval;
         CAmount nSubsidy = GetBlockSubsidy(nHeight, consensusParams);
         BOOST_CHECK(nSubsidy <= nInitialSubsidy);
         if (nHalvings < 2) {
@@ -41,13 +42,15 @@ static void TestBlockSubsidyHalvings(const Consensus::Params& consensusParams)
         }
         nPreviousSubsidy = nSubsidy;
     }
-    BOOST_CHECK_EQUAL(GetBlockSubsidy(1 + maxHalvings * consensusParams.nSubsidyHalvingInterval, consensusParams), 0);
+    BOOST_CHECK_EQUAL(GetBlockSubsidy(2 + maxHalvings * consensusParams.nSubsidyHalvingInterval, consensusParams), 0);
 }
 
 static void TestBlockSubsidyHalvings(int nSubsidyHalvingInterval)
 {
     Consensus::Params consensusParams;
     consensusParams.nSubsidyHalvingInterval = nSubsidyHalvingInterval;
+    consensusParams.nMaximumSupply = std::numeric_limits<CAmount>::max();
+    consensusParams.genesis_reward = 0;
     TestBlockSubsidyHalvings(consensusParams);
 }
 
@@ -63,7 +66,7 @@ BOOST_AUTO_TEST_CASE(subsidy_limit_test)
 {
     const auto chainParams = CreateChainParams(*m_node.args, ChainType::MAIN);
     CAmount nSum = 0;
-    for (int nHeight = 1; nHeight < 14000000; nHeight += 1000) {
+    for (int nHeight = 2; nHeight < 14000000; nHeight += 1000) {
         CAmount nSubsidy = GetBlockSubsidy(nHeight, chainParams->GetConsensus());
         BOOST_CHECK(nSubsidy <= 50 * COIN);
         nSum += nSubsidy * 1000;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2232,9 +2232,9 @@ PackageMempoolAcceptResult ProcessNewPackage(Chainstate& active_chainstate, CTxM
 CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams)
 {
     if (nHeight <= 0) return 0;
-    if (nHeight == 1) return 3'000'000 * COIN;
+    if (nHeight == 1) return consensusParams.genesis_reward;
 
-    const CAmount max_subsidy{8'000'000 * COIN - 3'000'000 * COIN};
+    const CAmount max_subsidy{consensusParams.nMaximumSupply - consensusParams.genesis_reward};
 
     int halvings = (nHeight - 2) / consensusParams.nSubsidyHalvingInterval;
     if (halvings >= 64) return 0;


### PR DESCRIPTION
## Summary
- add `genesis_reward` to `Consensus::Params`
- derive block subsidies from consensus parameters
- initialize `genesis_reward` for all chain parameters and update subsidy tests

## Testing
- `cmake -B build -G Ninja -DENABLE_WALLET=OFF -DBUILD_BITCOIN_QT=OFF` *(fails: libsecp256k1_zkp >= 0.6.1 not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c35be5f850832aac99bd2ff7a005d0