### PR TITLE
consensus: document Bitgold supply cap

### DIFF
--- a/src/consensus/amount.h
+++ b/src/consensus/amount.h
@@ -16,12 +16,10 @@ static constexpr CAmount COIN = 100000000;
 
 /** No amount larger than this (in satoshi) is valid.
  *
- * Note that this constant is *not* the total money supply, which in Bitcoin
- * currently happens to be less than 21,000,000 BTC for various reasons, but
- * rather a sanity check. As this sanity check is used by consensus-critical
- * validation code, the exact value of the MAX_MONEY constant is consensus
- * critical; in unusual circumstances like a(nother) overflow bug that allowed
- * for the creation of coins out of thin air modification could lead to a fork.
+ * Bitgold's monetary supply is capped at 8,000,000 coins. The genesis block
+ * mints a one-time reward of 3,000,000 coins, leaving at most 5,000,000 coins
+ * to be created by block subsidies. This serves as a consensus sanity check,
+ * and modification can lead to a fork if coins are created out of thin air.
  * */
 static constexpr CAmount MAX_MONEY = 8000000 * COIN;
 inline bool MoneyRange(const CAmount& nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }


### PR DESCRIPTION
## Summary
- detail Bitgold's 8M coin cap and 3M coin genesis reward in consensus amount comments

## Testing
- `python3 test/lint/lint-files.py src/consensus/amount.h` *(fails: several functional tests lack executable permissions)*

------
https://chatgpt.com/codex/tasks/task_b_68c35bea500c832a939cff6c226225ba