### PR TITLE
Rename user agent and message magic to BitGold

### DIFF
--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -20,7 +20,7 @@ using util::Join;
  * for both bitcoind and bitcoin-qt, to make it harder for attackers to
  * target servers or GUI users specifically.
  */
-const std::string UA_NAME("Satoshi");
+const std::string UA_NAME("BitGold");
 
 
 #include <bitcoin-build-info.h>

--- a/src/common/signmessage.cpp
+++ b/src/common/signmessage.cpp
@@ -21,7 +21,7 @@
  * Text used to signify that a signed message follows and to prevent
  * inadvertently signing a transaction.
  */
-const std::string MESSAGE_MAGIC = "Bitcoin Signed Message:\n";
+const std::string MESSAGE_MAGIC = "BitGold Signed Message:\n";
 
 MessageVerificationResult MessageVerify(
     const std::string& address,


### PR DESCRIPTION
## Summary
- rename default user agent string to `BitGold`
- update signed message magic to "BitGold Signed Message:\n"

## Testing
- `python3 test/lint/lint-include-guards.py src/clientversion.cpp src/common/signmessage.cpp`
- `python3 test/lint/lint-qt-translation.py`
- `cmake -B build -DBUILD_GUI=OFF -DWITH_ZMQ=OFF` *(fails: Could not find Boost)*

------
https://chatgpt.com/codex/tasks/task_b_68c3621dd758832abc48d92b6fa242c3