### PR TITLE
Update Windows resource metadata to bitgold

### DIFF
--- a/src/bitcoin-res.rc
+++ b/src/bitcoin-res.rc
@@ -15,13 +15,13 @@ BEGIN
         BLOCK "040904E4" // U.S. English - multilingual (hex)
         BEGIN
             VALUE "CompanyName",        CLIENT_NAME " project"
-            VALUE "FileDescription",    "bitcoin (Bitcoin wrapper executable that can call other executables)"
+            VALUE "FileDescription",    "bitgold (Bitgold wrapper executable that can call other executables)"
             VALUE "FileVersion",        CLIENT_VERSION_STRING
-            VALUE "InternalName",       "bitcoin"
+            VALUE "InternalName",       "bitgold"
             VALUE "LegalCopyright",     COPYRIGHT_STR
             VALUE "LegalTrademarks1",   "Distributed under the MIT software license, see the accompanying file COPYING or http://www.opensource.org/licenses/mit-license.php."
-            VALUE "OriginalFilename",   "bitcoin.exe"
-            VALUE "ProductName",        "bitcoin"
+            VALUE "OriginalFilename",   "bitgold.exe"
+            VALUE "ProductName",        "bitgold"
             VALUE "ProductVersion",     CLIENT_VERSION_STRING
         END
     END


### PR DESCRIPTION
## Summary
- rename user-facing metadata in bitcoin-res.rc from bitcoin to bitgold

## Testing
- `x86_64-w64-mingw32-windres src/bitcoin-res.rc -O coff -I src -I build/src -o build/bitcoin-res.o`
- `ls -l build/bitcoin-res.o`


------
https://chatgpt.com/codex/tasks/task_b_68c3632626ac832aafbfb31896847445