### PR TITLE
Implement stake modifier v3 and PoS retarget algorithm

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -302,6 +302,8 @@ add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
   policy/settings.cpp
   policy/priority.cpp
   policy/truc_policy.cpp
+  pow.cpp
+  kernel/stake.cpp
   pos/stake.cpp
   pos/stakemodifier.cpp
   pos/difficulty.cpp

--- a/src/kernel/CMakeLists.txt
+++ b/src/kernel/CMakeLists.txt
@@ -19,6 +19,8 @@ add_library(bitcoinkernel
   disconnected_transactions.cpp
   mempool_removal_reason.cpp
   mempool_priority.cpp
+  stake.cpp
+  ../pow.cpp
   ../arith_uint256.cpp
   ../chain.cpp
   ../coins.cpp

--- a/src/kernel/stake.cpp
+++ b/src/kernel/stake.cpp
@@ -1,0 +1,121 @@
+#include <kernel/stake.h>
+
+#include <arith_uint256.h>
+#include <hash.h>
+#include <pubkey.h>
+#include <script/script.h>
+#include <util/time.h>
+#include <validation.h>
+
+namespace kernel {
+
+namespace {
+uint256 g_last_modifier;
+}
+
+uint256 ComputeStakeModifierV3(const CBlockIndex* pindexPrev, const uint256& prev_modifier)
+{
+    HashWriter ss;
+    ss << prev_modifier;
+    if (pindexPrev) {
+        ss << pindexPrev->GetBlockHash() << pindexPrev->nHeight << pindexPrev->nTime;
+    }
+    return ss.GetHash();
+}
+
+static uint256 ComputeKernelHash(const uint256& stake_modifier,
+                                 const COutPoint& prevout,
+                                 unsigned int nTimeBlockFrom,
+                                 unsigned int nTimeTx)
+{
+    HashWriter ss;
+    ss << stake_modifier << prevout.hash << prevout.n << nTimeBlockFrom << nTimeTx;
+    return ss.GetHash();
+}
+
+bool CheckStakeKernelHash(const CBlockIndex* pindexPrev, unsigned int nBits,
+                          uint256 hashBlockFrom, unsigned int nTimeBlockFrom,
+                          CAmount amount, const COutPoint& prevout,
+                          unsigned int nTimeTx, uint256& hashProofOfStake,
+                          const Consensus::Params& params)
+{
+    if (!pindexPrev) return false;
+    if (nTimeTx <= nTimeBlockFrom) return false;
+    if ((nTimeTx & params.nStakeTimestampMask) != 0) return false;
+
+    bool fNegative = false;
+    bool fOverflow = false;
+    arith_uint256 bnTarget;
+    bnTarget.SetCompact(nBits, &fNegative, &fOverflow);
+    if (fNegative || fOverflow || bnTarget == 0) return false;
+
+    arith_uint256 bnWeight(amount);
+    bnTarget *= bnWeight;
+
+    g_last_modifier = ComputeStakeModifierV3(pindexPrev, g_last_modifier);
+    hashProofOfStake = ComputeKernelHash(g_last_modifier, prevout, nTimeBlockFrom, nTimeTx);
+    return UintToArith256(hashProofOfStake) <= bnTarget;
+}
+
+bool IsProofOfStake(const CBlock& block)
+{
+    if (block.vtx.size() < 2) return false;
+    const CTransaction& tx = *block.vtx[1];
+    if (tx.IsCoinBase()) return false;
+    if (tx.vin.empty() || tx.vout.size() < 2) return false;
+    if (!tx.vout[0].scriptPubKey.empty()) return false;
+    return true;
+}
+
+bool CheckBlockSignature(const CBlock& block)
+{
+    if (!IsProofOfStake(block)) {
+        return block.vchBlockSig.empty();
+    }
+    if (block.vchBlockSig.empty()) return false;
+
+    const CTransaction& tx{*block.vtx[1]};
+    if (tx.vin.empty()) return false;
+    const CScript& scriptSig{tx.vin[0].scriptSig};
+    CScript::const_iterator it = scriptSig.begin();
+    opcodetype op;
+    std::vector<unsigned char> vchSig;
+    std::vector<unsigned char> vchPub;
+    if (!scriptSig.GetOp(it, op, vchSig)) return false;
+    if (!scriptSig.GetOp(it, op, vchPub)) return false;
+    CPubKey pubkey(vchPub);
+    if (!pubkey.IsValid()) return false;
+    return pubkey.Verify(block.GetHash(), block.vchBlockSig);
+}
+
+bool ContextualCheckProofOfStake(const CBlock& block,
+                                 const CBlockIndex* pindexPrev,
+                                 const CCoinsViewCache& view,
+                                 const CChain& chain,
+                                 const Consensus::Params& params)
+{
+    if (!pindexPrev) return false;
+    if (!IsProofOfStake(block)) return false;
+
+    const CTransaction& coinstake{*block.vtx[1]};
+    if (block.nTime != coinstake.nLockTime) return false;
+    if ((block.nTime & params.nStakeTimestampMask) != 0) return false;
+    if (coinstake.vin.empty()) return false;
+
+    const CTxIn& txin{coinstake.vin[0]};
+    const Coin& coin = view.AccessCoin(txin.prevout);
+    if (coin.IsSpent()) return false;
+    const CBlockIndex* pindexFrom = chain[coin.nHeight];
+    if (!pindexFrom) return false;
+    unsigned int nTimeBlockFrom = pindexFrom->GetBlockTime();
+    uint256 hashProofOfStake;
+    if (!CheckStakeKernelHash(pindexPrev, block.nBits,
+                              pindexFrom->GetBlockHash(), nTimeBlockFrom,
+                              coin.out.nValue, txin.prevout,
+                              block.nTime, hashProofOfStake, params)) {
+        return false;
+    }
+    return true;
+}
+
+} // namespace kernel

--- a/src/kernel/stake.h
+++ b/src/kernel/stake.h
@@ -1,0 +1,54 @@
+#ifndef BITCOIN_KERNEL_STAKE_H
+#define BITCOIN_KERNEL_STAKE_H
+
+#include <consensus/amount.h>
+#include <consensus/params.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
+#include <uint256.h>
+#include <coins.h>
+#include <chain.h>
+#include <util/time.h>
+
+namespace kernel {
+
+/** Default timestamp mask used by proof-of-stake blocks */
+static constexpr unsigned int STAKE_TIMESTAMP_MASK = 0xF;
+
+/** Compute stake modifier version 3.
+ *  The modifier mixes the previous modifier with key fields from the
+ *  previous block to make staking deterministic while preventing grinding.
+ */
+uint256 ComputeStakeModifierV3(const CBlockIndex* pindexPrev, const uint256& prev_modifier);
+
+/** Check that a stake kernel hash meets the target specified by nBits. */
+bool CheckStakeKernelHash(const CBlockIndex* pindexPrev, unsigned int nBits,
+                          uint256 hashBlockFrom, unsigned int nTimeBlockFrom,
+                          CAmount amount, const COutPoint& prevout,
+                          unsigned int nTimeTx, uint256& hashProofOfStake,
+                          const Consensus::Params& params);
+
+/** Returns true if the block contains a valid coinstake transaction. */
+bool IsProofOfStake(const CBlock& block);
+
+/** Verify the signature on a proof-of-stake block. */
+bool CheckBlockSignature(const CBlock& block);
+
+/** Contextual checks for a proof-of-stake block. */
+bool ContextualCheckProofOfStake(const CBlock& block,
+                                 const CBlockIndex* pindexPrev,
+                                 const CCoinsViewCache& view,
+                                 const CChain& chain,
+                                 const Consensus::Params& params);
+
+/** Basic timestamp checks for a staked block. */
+inline bool CheckStakeTimestamp(const CBlockHeader& h, const Consensus::Params& p)
+{
+    if ((h.nTime & p.nStakeTimestampMask) != 0) return false;
+    if (h.nTime > GetTime() + 15) return false;
+    return true;
+}
+
+} // namespace kernel
+
+#endif // BITCOIN_KERNEL_STAKE_H

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1,0 +1,15 @@
+#include <miner.h>
+#include <validation.h>
+
+/**
+ * Legacy proof-of-work mining is disabled after the genesis block.
+ * This placeholder guards any accidental calls into mining routines.
+ */
+bool MineBlock(const CChain& chain, CBlock& block)
+{
+    if (chain.Height() >= 0) {
+        // PoW disabled once a chain exists beyond genesis.
+        return false;
+    }
+    return false;
+}

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -1,0 +1,28 @@
+#include <pow.h>
+
+#include <arith_uint256.h>
+#include <chain.h>
+#include <consensus/params.h>
+
+unsigned int GetPoSNextWorkRequired(const CBlockIndex* pindexLast, int64_t nBlockTime, const Consensus::Params& params)
+{
+    arith_uint256 bnLimit = UintToArith256(params.posLimit);
+    if (pindexLast == nullptr) {
+        return bnLimit.GetCompact();
+    }
+
+    int64_t target_spacing = 8 * 60; // 8 minutes
+    int64_t interval = params.DifficultyAdjustmentInterval();
+    int64_t actual_spacing = nBlockTime - pindexLast->GetBlockTime();
+    if (actual_spacing < 0) actual_spacing = target_spacing;
+
+    arith_uint256 bnNew;
+    bnNew.SetCompact(pindexLast->nBits);
+    bnNew *= ((interval - 1) * target_spacing + 2 * actual_spacing);
+    bnNew /= ((interval + 1) * target_spacing);
+
+    if (bnNew <= 0 || bnNew > bnLimit) {
+        bnNew = bnLimit;
+    }
+    return bnNew.GetCompact();
+}

--- a/src/pow.h
+++ b/src/pow.h
@@ -1,0 +1,15 @@
+#ifndef BITCOIN_POW_H
+#define BITCOIN_POW_H
+
+#include <cstdint>
+
+class CBlockIndex;
+struct CBlockHeader;
+namespace Consensus { struct Params; }
+
+/**
+ * Return the next proof-of-stake target using an 8 minute retarget rule.
+ */
+unsigned int GetPoSNextWorkRequired(const CBlockIndex* pindexLast, int64_t nBlockTime, const Consensus::Params& params);
+
+#endif // BITCOIN_POW_H

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -6,8 +6,8 @@
 #include <bitcoin-build-config.h> // IWYU pragma: keep
 
 #include <common/args.h>
-#include <pos/difficulty.h>
-#include <pos/stake.h>
+#include <pow.h>
+#include <kernel/stake.h>
 #include <validation.h>
 
 #include <arith_uint256.h>
@@ -90,6 +90,10 @@ using kernel::CCoinsStats;
 using kernel::CoinStatsHashType;
 using kernel::ComputeUTXOStats;
 using kernel::Notifications;
+using kernel::CheckBlockSignature;
+using kernel::ContextualCheckProofOfStake;
+using kernel::IsProofOfStake;
+using kernel::CheckStakeTimestamp;
 
 using fsbridge::FopenFn;
 using node::BlockManager;
@@ -2264,7 +2268,7 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast,
     assert(pindexLast);
 
     if (params.fEnablePoS && pindexLast->nHeight + 1 >= params.posActivationHeight) {
-        return GetPoSNextTargetRequired(pindexLast, pblock->GetBlockTime(), params);
+        return GetPoSNextWorkRequired(pindexLast, pblock->GetBlockTime(), params);
     }
 
     // With proof-of-work removed, keep the previous difficulty for premine blocks.


### PR DESCRIPTION
## Summary
- add stake modifier v3 and kernel helpers for staking, signature checks, and contextual validation
- introduce 8‑minute proof‑of‑stake retarget algorithm and wire it into difficulty calculation
- guard legacy proof‑of‑work mining after the genesis block

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "Boost" (requested version 1.73.0))*

------
https://chatgpt.com/codex/tasks/task_b_68c363d68a3c832a99644a0964f64478