### PR TITLE
Use priority point system for mempool ordering

### DIFF
--- a/src/node/mempool_args.cpp
+++ b/src/node/mempool_args.cpp
@@ -78,7 +78,9 @@ util::Result<void> ApplyArgsManOptions(const ArgsManager& argsman, const CChainP
         LogPrintf("Increasing minrelaytxfee to %s to match incrementalrelayfee\n", mempool_opts.min_relay_feerate.ToString());
     }
 
-    g_enable_priority = argsman.GetBoolArg("-bgdpriority", false);
+    // Enable the priority-based mempool point system by default. It can be
+    // disabled by passing -bgdpriority=0 at startup.
+    g_enable_priority = argsman.GetBoolArg("-bgdpriority", true);
 
     // Feerate used to define dust.  Shouldn't be changed lightly as old
     // implementations may inadvertently create non-standard transactions

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -23,8 +23,9 @@ class CScript;
 extern bool g_enable_priority;
 extern int64_t g_max_priority;
 
-/** Default for -blockmaxweight, which controls the range of block weights the mining code will create **/
-static constexpr unsigned int DEFAULT_BLOCK_MAX_WEIGHT{20000000};
+/** Default for -blockmaxweight, which controls the range of block weights the mining code will create.
+ *  Set to the network's consensus limit of 20,000,000 weight units. */
+static constexpr unsigned int DEFAULT_BLOCK_MAX_WEIGHT{MAX_BLOCK_WEIGHT};
 /** Default for -blockreservedweight **/
 static constexpr unsigned int DEFAULT_BLOCK_RESERVED_WEIGHT{8000};
 /** This accounts for the block header, var_int encoding of the transaction count and a minimally viable


### PR DESCRIPTION
## Summary
- tie default block weight to consensus limit of 20M WU
- enable priority point system by default
- sort mempool transactions by priority points with feerate tie-breaker

## Testing
- `cmake -B build -GNinja` *(fails: libsecp256k1_zkp >= 0.6.1 not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c363e440e0832abb1a6bb243145674