### PR TITLE
Adjust block subsidy schedule

### DIFF
--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -147,9 +147,9 @@ struct Params {
     uint256 posLimitLower;
     // Target spacing between staked blocks (seconds)
     int64_t nStakeTargetSpacing{8 * 60};
-    // Maximum allowed coin supply (satoshis)
+    //! Total coin supply allowed by consensus (including genesis block)
     CAmount nMaximumSupply{0};
-    // Reward paid in the genesis block (satoshis)
+    //! Reward paid in the genesis block (satoshis)
     CAmount genesis_reward{0};
     /** The best chain should have at least this much work */
     uint256 nMinimumChainWork;

--- a/src/test/validation_tests.cpp
+++ b/src/test/validation_tests.cpp
@@ -29,10 +29,10 @@ static void TestBlockSubsidyHalvings(const Consensus::Params& consensusParams)
     int maxHalvings = 64;
     CAmount nInitialSubsidy = 50 * COIN;
 
-    CAmount nPreviousSubsidy = nInitialSubsidy * 2; // for height == 2
+    CAmount nPreviousSubsidy = nInitialSubsidy * 2; // for height == 1
     BOOST_CHECK_EQUAL(nPreviousSubsidy, nInitialSubsidy * 2);
     for (int nHalvings = 0; nHalvings < maxHalvings; nHalvings++) {
-        int nHeight = 2 + nHalvings * consensusParams.nSubsidyHalvingInterval;
+        int nHeight = 1 + nHalvings * consensusParams.nSubsidyHalvingInterval;
         CAmount nSubsidy = GetBlockSubsidy(nHeight, consensusParams);
         BOOST_CHECK(nSubsidy <= nInitialSubsidy);
         if (nHalvings < 2) {
@@ -42,7 +42,7 @@ static void TestBlockSubsidyHalvings(const Consensus::Params& consensusParams)
         }
         nPreviousSubsidy = nSubsidy;
     }
-    BOOST_CHECK_EQUAL(GetBlockSubsidy(2 + maxHalvings * consensusParams.nSubsidyHalvingInterval, consensusParams), 0);
+    BOOST_CHECK_EQUAL(GetBlockSubsidy(1 + maxHalvings * consensusParams.nSubsidyHalvingInterval, consensusParams), 0);
 }
 
 static void TestBlockSubsidyHalvings(int nSubsidyHalvingInterval)
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE(subsidy_limit_test)
 {
     const auto chainParams = CreateChainParams(*m_node.args, ChainType::MAIN);
     CAmount nSum = 0;
-    for (int nHeight = 2; nHeight < 14000000; nHeight += 1000) {
+    for (int nHeight = 1; nHeight < 14000000; nHeight += 1000) {
         CAmount nSubsidy = GetBlockSubsidy(nHeight, chainParams->GetConsensus());
         BOOST_CHECK(nSubsidy <= 50 * COIN);
         nSum += nSubsidy * 1000;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2231,18 +2231,18 @@ PackageMempoolAcceptResult ProcessNewPackage(Chainstate& active_chainstate, CTxM
 
 CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams)
 {
-    if (nHeight <= 0) return 0;
-    if (nHeight == 1) return consensusParams.genesis_reward;
+    if (nHeight < 0) return 0;
+    if (nHeight == 0) return consensusParams.genesis_reward;
 
     const CAmount max_subsidy{consensusParams.nMaximumSupply - consensusParams.genesis_reward};
 
-    int halvings = (nHeight - 2) / consensusParams.nSubsidyHalvingInterval;
+    int halvings = (nHeight - 1) / consensusParams.nSubsidyHalvingInterval;
     if (halvings >= 64) return 0;
     CAmount subsidy = 50 * COIN;
     subsidy >>= halvings;
 
     CAmount minted{0};
-    int height = nHeight - 2;
+    int height = nHeight - 1;
     CAmount current_subsidy = 50 * COIN;
     while (height > 0 && current_subsidy > 0) {
         int blocks = std::min(height, consensusParams.nSubsidyHalvingInterval);


### PR DESCRIPTION
## Summary
- ensure genesis block mints 3M BGD and mining starts at 50 BGD
- enforce supply cap and 90k-block halving from height 1
- update consensus parameters comments and subsidy unit tests

## Testing
- `cmake -S . -B build -GNinja` *(fails: libsecp256k1_zkp >= 0.6.1 not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c363f29294832aaa7084d4a15a2eb9