### PR TITLE
Use consensus stake target spacing

### DIFF
--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -11,7 +11,7 @@ unsigned int GetPoSNextWorkRequired(const CBlockIndex* pindexLast, int64_t nBloc
         return bnLimit.GetCompact();
     }
 
-    int64_t target_spacing = 8 * 60; // 8 minutes
+    int64_t target_spacing = params.nStakeTargetSpacing;
     int64_t interval = params.DifficultyAdjustmentInterval();
     int64_t actual_spacing = nBlockTime - pindexLast->GetBlockTime();
     if (actual_spacing < 0) actual_spacing = target_spacing;


### PR DESCRIPTION
## Summary
- use `Consensus::Params::nStakeTargetSpacing` in proof-of-stake difficulty calculation
- test PoS difficulty adjustment with non-default stake target spacing

## Testing
- `cmake -S . -B build -GNinja` *(fails: libsecp256k1_zkp >= 0.6.1 not found)*


------
https://chatgpt.com/codex/tasks/task_b_68c4133fb230832a84c8c7a4dcd740c7