### PR TITLE
Use consensus stake timestamp mask

### DIFF
--- a/src/kernel/stake.h
+++ b/src/kernel/stake.h
@@ -12,9 +12,6 @@
 
 namespace kernel {
 
-/** Default timestamp mask used by proof-of-stake blocks */
-static constexpr unsigned int STAKE_TIMESTAMP_MASK = 0xF;
-
 /** Compute stake modifier version 3.
  *  The modifier mixes the previous modifier with key fields from the
  *  previous block to make staking deterministic while preventing grinding.

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -686,7 +686,7 @@ bool CreatePosBlock(wallet::CWallet& wallet)
     unsigned int nTime = std::max<int64_t>(
         GetMinimumTime(pindexPrev, consensus.DifficultyAdjustmentInterval()),
         TicksSinceEpoch<std::chrono::seconds>(NodeClock::now()));
-    nTime &= ~STAKE_TIMESTAMP_MASK;
+    nTime &= ~consensus.nStakeTimestampMask;
     block.nTime = nTime;
     block.nBits = pindexPrev->nBits;
     block.nNonce = 0;

--- a/src/pos/stake.h
+++ b/src/pos/stake.h
@@ -12,8 +12,6 @@
 
 class CBlockIndex;
 
-// Default timestamp granularity for staked blocks (16 seconds, PoSV3.1)
-static constexpr unsigned int STAKE_TIMESTAMP_MASK = 0xF;
 // Default minimum coin age for staking (8 hours, PoSV3.1)
 // Network-specific values are provided via consensus parameters
 static constexpr int64_t MIN_STAKE_AGE = 8 * 60 * 60;

--- a/src/pos/validator.cpp
+++ b/src/pos/validator.cpp
@@ -1,5 +1,4 @@
 #include "pos/validator.h"
-#include "pos/stake.h"
 
 #include <hash.h>
 #include <chain.h>
@@ -11,17 +10,17 @@ Validator::Validator(uint64_t stake_amount)
       m_locked_until(0),
       m_active(false) {}
 
-void Validator::Activate(int64_t current_time)
+void Validator::Activate(int64_t current_time, const Consensus::Params& params)
 {
-    current_time &= ~STAKE_TIMESTAMP_MASK;
+    current_time &= ~params.nStakeTimestampMask;
     if (m_stake_amount >= MIN_STAKE && current_time >= m_locked_until) {
         m_active = true;
     }
 }
 
-void Validator::ScheduleUnstake(int64_t current_time)
+void Validator::ScheduleUnstake(int64_t current_time, const Consensus::Params& params)
 {
-    current_time &= ~STAKE_TIMESTAMP_MASK;
+    current_time &= ~params.nStakeTimestampMask;
     m_locked_until = current_time + UNSTAKE_DELAY;
     m_active = false;
 }

--- a/src/pos/validator.h
+++ b/src/pos/validator.h
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 #include <uint256.h>
+#include <consensus/params.h>
 
 class CBlockIndex;
 
@@ -14,10 +15,10 @@ public:
     explicit Validator(uint64_t stake_amount);
 
     // Attempt to activate the validator if stake and time requirements are met.
-    void Activate(int64_t current_time);
+    void Activate(int64_t current_time, const Consensus::Params& params);
 
     // Schedule an unstake request; validator becomes inactive until time passes.
-    void ScheduleUnstake(int64_t current_time);
+    void ScheduleUnstake(int64_t current_time, const Consensus::Params& params);
 
     bool IsActive() const { return m_active; }
 

--- a/test/functional/pos/invalid_timestamp.py
+++ b/test/functional/pos/invalid_timestamp.py
@@ -15,7 +15,7 @@ from test_framework.messages import (
 from test_framework.script import CScript
 from test_framework.util import assert_equal
 
-STAKE_TIMESTAMP_MASK = 0xF
+STAKE_TIMESTAMP_MASK = None
 MIN_STAKE_AGE = 60 * 60
 
 
@@ -50,6 +50,8 @@ class PosInvalidTimestampTest(BitcoinTestFramework):
 
     def run_test(self):
         node = self.nodes[0]
+        global STAKE_TIMESTAMP_MASK
+        STAKE_TIMESTAMP_MASK = node.getblockchaininfo()["pos_timestamp_mask"]
         addr = node.getnewaddress()
         node.generatetoaddress(150, addr)
 

--- a/test/functional/pos/long_range_attack.py
+++ b/test/functional/pos/long_range_attack.py
@@ -14,7 +14,7 @@ from test_framework.messages import (
 from test_framework.script import CScript
 from test_framework.util import assert_equal
 
-STAKE_TIMESTAMP_MASK = 0xF
+STAKE_TIMESTAMP_MASK = None
 MIN_STAKE_AGE = 60 * 60
 
 
@@ -49,6 +49,8 @@ class PosLongRangeAttackTest(BitcoinTestFramework):
 
     def run_test(self):
         node = self.nodes[0]
+        global STAKE_TIMESTAMP_MASK
+        STAKE_TIMESTAMP_MASK = node.getblockchaininfo()["pos_timestamp_mask"]
         addr = node.getnewaddress()
         node.generatetoaddress(200, addr)
 

--- a/test/functional/pos/nothing_at_stake.py
+++ b/test/functional/pos/nothing_at_stake.py
@@ -14,7 +14,7 @@ from test_framework.messages import (
 from test_framework.script import CScript
 from test_framework.util import assert_equal
 
-STAKE_TIMESTAMP_MASK = 0xF
+STAKE_TIMESTAMP_MASK = None
 MIN_STAKE_AGE = 60 * 60
 
 
@@ -49,6 +49,8 @@ class PosNothingAtStakeTest(BitcoinTestFramework):
 
     def run_test(self):
         node = self.nodes[0]
+        global STAKE_TIMESTAMP_MASK
+        STAKE_TIMESTAMP_MASK = node.getblockchaininfo()["pos_timestamp_mask"]
         addr = node.getnewaddress()
         node.generatetoaddress(150, addr)
 

--- a/test/functional/pos/timestamp_skew.py
+++ b/test/functional/pos/timestamp_skew.py
@@ -14,7 +14,7 @@ from test_framework.messages import (
 from test_framework.script import CScript
 from test_framework.util import assert_equal
 
-STAKE_TIMESTAMP_MASK = 0xF
+STAKE_TIMESTAMP_MASK = None
 MIN_STAKE_AGE = 60 * 60
 
 
@@ -49,6 +49,8 @@ class PosTimestampSkewTest(BitcoinTestFramework):
 
     def run_test(self):
         node = self.nodes[0]
+        global STAKE_TIMESTAMP_MASK
+        STAKE_TIMESTAMP_MASK = node.getblockchaininfo()["pos_timestamp_mask"]
         addr = node.getnewaddress()
         node.generatetoaddress(150, addr)
 

--- a/test/functional/pos_activation.py
+++ b/test/functional/pos_activation.py
@@ -15,7 +15,7 @@ from test_framework.messages import (
 from test_framework.script import CScript
 from test_framework.util import assert_equal
 
-STAKE_TIMESTAMP_MASK = 0xF
+STAKE_TIMESTAMP_MASK = None
 MIN_STAKE_AGE = 8 * 60 * 60
 
 
@@ -109,6 +109,8 @@ class PosActivationTest(BitcoinTestFramework):
 
     def run_test(self):
         node0, node1 = self.nodes
+        global STAKE_TIMESTAMP_MASK
+        STAKE_TIMESTAMP_MASK = node0.getblockchaininfo()["pos_timestamp_mask"]
         addr = node0.getnewaddress()
         node0.generatetoaddress(200, addr)
         self.sync_all()

--- a/test/functional/pos_block_acceptance.py
+++ b/test/functional/pos_block_acceptance.py
@@ -15,7 +15,7 @@ from test_framework.messages import (
 from test_framework.script import CScript
 from test_framework.util import assert_equal
 
-STAKE_TIMESTAMP_MASK = 0xF
+STAKE_TIMESTAMP_MASK = None
 MIN_STAKE_AGE = 60 * 60
 
 
@@ -50,6 +50,8 @@ class PosBlockAcceptanceTest(BitcoinTestFramework):
 
     def run_test(self):
         node = self.nodes[0]
+        global STAKE_TIMESTAMP_MASK
+        STAKE_TIMESTAMP_MASK = node.getblockchaininfo()["pos_timestamp_mask"]
         addr = node.getnewaddress()
         node.generatetoaddress(150, addr)
 

--- a/test/functional/pos_block_staking.py
+++ b/test/functional/pos_block_staking.py
@@ -15,7 +15,7 @@ from test_framework.messages import (
 from test_framework.script import CScript
 from test_framework.util import assert_equal
 
-STAKE_TIMESTAMP_MASK = 0xF
+STAKE_TIMESTAMP_MASK = None
 MIN_STAKE_AGE = 60 * 60
 
 
@@ -50,6 +50,8 @@ class PosBlockStakingTest(BitcoinTestFramework):
 
     def run_test(self):
         node = self.nodes[0]
+        global STAKE_TIMESTAMP_MASK
+        STAKE_TIMESTAMP_MASK = node.getblockchaininfo()["pos_timestamp_mask"]
         addr = node.getnewaddress()
         node.generatetoaddress(150, addr)
 

--- a/test/functional/pos_difficulty.py
+++ b/test/functional/pos_difficulty.py
@@ -15,7 +15,7 @@ from test_framework.messages import (
 from test_framework.script import CScript
 from test_framework.util import assert_equal
 
-STAKE_TIMESTAMP_MASK = 0xF
+STAKE_TIMESTAMP_MASK = None
 MIN_STAKE_AGE = 60 * 60
 TARGET_SPACING = 16
 INTERVAL = 24 * 60 * 60 // (8 * 60)  # matches regtest params
@@ -121,6 +121,8 @@ class PosDifficultyTest(BitcoinTestFramework):
 
     def run_test(self):
         node = self.nodes[0]
+        global STAKE_TIMESTAMP_MASK
+        STAKE_TIMESTAMP_MASK = node.getblockchaininfo()["pos_timestamp_mask"]
         addr = node.getnewaddress()
         node.generatetoaddress(150, addr)
 

--- a/test/functional/pos_fakestake_mitigation.py
+++ b/test/functional/pos_fakestake_mitigation.py
@@ -16,7 +16,7 @@ from test_framework.script import CScript
 from test_framework.util import assert_equal
 import random
 
-STAKE_TIMESTAMP_MASK = 0xF
+STAKE_TIMESTAMP_MASK = None
 MIN_STAKE_AGE = 60 * 60
 
 
@@ -74,6 +74,8 @@ class PosFakeStakeMitigationTest(BitcoinTestFramework):
 
     def run_test(self):
         node = self.nodes[0]
+        global STAKE_TIMESTAMP_MASK
+        STAKE_TIMESTAMP_MASK = node.getblockchaininfo()["pos_timestamp_mask"]
         addr = node.getnewaddress()
         node.generatetoaddress(150, addr)
 

--- a/test/functional/pos_reorg.py
+++ b/test/functional/pos_reorg.py
@@ -15,7 +15,7 @@ from test_framework.messages import (
 from test_framework.script import CScript
 from test_framework.util import assert_equal
 
-STAKE_TIMESTAMP_MASK = 0xF
+STAKE_TIMESTAMP_MASK = None
 MIN_STAKE_AGE = 60 * 60
 
 
@@ -108,6 +108,8 @@ class PosReorgTest(BitcoinTestFramework):
 
     def run_test(self):
         node0, node1 = self.nodes
+        global STAKE_TIMESTAMP_MASK
+        STAKE_TIMESTAMP_MASK = node0.getblockchaininfo()["pos_timestamp_mask"]
         addr0 = node0.getnewaddress()
         node0.generatetoaddress(150, addr0)
         self.sync_all()

--- a/test/functional/pos_reward_clipping.py
+++ b/test/functional/pos_reward_clipping.py
@@ -14,7 +14,7 @@ from test_framework.messages import (
 from test_framework.script import CScript
 from test_framework.util import assert_equal
 
-STAKE_TIMESTAMP_MASK = 0xF
+STAKE_TIMESTAMP_MASK = None
 MIN_STAKE_AGE = 60 * 60
 MAX_AGE_WEIGHT = 60 * 60 * 24 * 30
 
@@ -50,6 +50,8 @@ class PosRewardClippingTest(BitcoinTestFramework):
 
     def run_test(self):
         node = self.nodes[0]
+        global STAKE_TIMESTAMP_MASK
+        STAKE_TIMESTAMP_MASK = node.getblockchaininfo()["pos_timestamp_mask"]
         addr = node.getnewaddress()
         node.generatetoaddress(110, addr)
 

--- a/test/functional/wallet_stake_miner.py
+++ b/test/functional/wallet_stake_miner.py
@@ -5,7 +5,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.messages import COIN, hash256, uint256_from_compact
 from test_framework.util import assert_equal
 
-STAKE_TIMESTAMP_MASK = 0xF
+STAKE_TIMESTAMP_MASK = None
 MIN_STAKE_AGE = 60 * 60
 
 
@@ -56,6 +56,8 @@ class StakeMinerLifecycleTest(BitcoinTestFramework):
 
     def run_test(self):
         node = self.nodes[0]
+        global STAKE_TIMESTAMP_MASK
+        STAKE_TIMESTAMP_MASK = node.getblockchaininfo()["pos_timestamp_mask"]
         addr = node.getnewaddress()
         node.generatetoaddress(200, addr)
 


### PR DESCRIPTION
## Summary
- remove hard-coded stake timestamp mask constant
- derive stake timestamp masking from consensus parameters and expose to tests

## Testing
- `python3 -m py_compile test/functional/pos/invalid_timestamp.py test/functional/pos/timestamp_skew.py test/functional/pos/nothing_at_stake.py test/functional/pos/long_range_attack.py test/functional/pos_activation.py test/functional/pos_block_acceptance.py test/functional/pos_reward_clipping.py test/functional/pos_difficulty.py test/functional/pos_fakestake_mitigation.py test/functional/pos_reorg.py test/functional/pos_block_staking.py test/functional/wallet_stake_miner.py`
- `test/functional/test_runner.py test/functional/pos/invalid_timestamp.py` *(fails: FileNotFoundError: No such file or directory: '/workspace/bitcoin/test/functional/../config.ini')*

------
https://chatgpt.com/codex/tasks/task_b_68c40a692980832aa5a30d8fe206b665