### PR TITLE
Remove unused COINSTAKE P2P message

### DIFF
--- a/doc/pos31_audit.md
+++ b/doc/pos31_audit.md
@@ -17,7 +17,7 @@ The repository already contains a sizeable PoS implementation:
 * **Stake modifier handling** – `src/pos/stakemodifier.cpp` provides modifier computation and `src/node/stake_modifier_manager.cpp` tracks and caches modifiers for validation and P2P.
 * **Difficulty retargeting** – `src/pos/difficulty.cpp` supplies a PoS retarget routine used by `GetNextWorkRequired`.
 * **Wallet staking** – `src/wallet/bitgoldstaker.cpp` contains a staking loop that constructs and signs coinstakes and submits PoS blocks.
-* **Network protocol support** – new P2P message types (`COINSTAKE`, `STAKEMODIFIER`) are declared in `src/protocol.h` and handled throughout `net.cpp`, `protocol.cpp`, and `net_processing.cpp`.
+* **Network protocol support** – a new P2P message type (`STAKEMODIFIER`) is declared in `src/protocol.h` and handled throughout `net.cpp`, `protocol.cpp`, and `net_processing.cpp`.
 * **Chain parameter wiring** – `src/kernel/chainparams.cpp` and `src/chainparams.cpp` expose `-posactivationheight` and set `nStakeTimestampMask` for various networks.
 * **Tests and docs** – multiple functional tests (`test/functional/feature_posv3.py`, `test/functional/pos_block_staking.py`, `test/functional/pos_reorg.py`) and user documentation (`doc/staking.md`, `doc/bitgoldstaking.md`, `doc/pos3.1-overview.md`, etc.) already exist.
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3826,7 +3826,7 @@ void CConnman::PushMessage(CNode* pnode, CSerializedNetMsg&& msg)
 
     // PoS-specific inventory and relay policy: only relay PoS messages to peers
     // that have explicitly enabled PoS relay support.
-    if ((msg.m_type == NetMsgType::COINSTAKE || msg.m_type == NetMsgType::STAKEMODIFIER) && !pnode->m_pos_enabled) {
+    if (msg.m_type == NetMsgType::STAKEMODIFIER && !pnode->m_pos_enabled) {
         return;
     }
     if (gArgs.GetBoolArg("-capturemessages", false)) {

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -69,7 +69,6 @@ std::string CInv::GetMessageType() const
     case MSG_BLOCK: return cmd.append(NetMsgType::BLOCK);
     case MSG_FILTERED_BLOCK: return cmd.append(NetMsgType::MERKLEBLOCK);
     case MSG_CMPCT_BLOCK: return cmd.append(NetMsgType::CMPCTBLOCK);
-    case MSG_COINSTAKE: return cmd.append(NetMsgType::COINSTAKE);
     case MSG_STAKE_MODIFIER: return cmd.append(NetMsgType::STAKEMODIFIER);
     default:
         throw std::out_of_range(strprintf("CInv::GetMessageType(): type=%d unknown type", type));

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -116,10 +116,6 @@ inline constexpr const char* GETHEADERS{"getheaders"};
  */
 inline constexpr const char* TX{"tx"};
 /**
- * The coinstake message transmits a single coinstake transaction.
- */
-inline constexpr const char* COINSTAKE{"coinstake"};
-/**
  * The headers message sends one or more block headers to a node which
  * previously requested certain headers with a getheaders message.
  * @since protocol version 31800.
@@ -291,7 +287,6 @@ inline const std::array ALL_NET_MESSAGE_TYPES{std::to_array<std::string>({
     NetMsgType::GETBLOCKS,
     NetMsgType::GETHEADERS,
     NetMsgType::TX,
-    NetMsgType::COINSTAKE,
     NetMsgType::HEADERS,
     NetMsgType::BLOCK,
     NetMsgType::GETSTAKEMODIFIER,
@@ -496,8 +491,7 @@ enum GetDataMsg : uint32_t {
     MSG_TX = 1,
     MSG_BLOCK = 2,
     MSG_WTX = 5, //!< Defined in BIP 339
-    MSG_COINSTAKE = 6,
-    MSG_STAKE_MODIFIER = 7,
+    MSG_STAKE_MODIFIER = 6,
     // The following can only occur in getdata. Invs always use TX/WTX or BLOCK.
     MSG_FILTERED_BLOCK = 3,                           //!< Defined in BIP37
     MSG_CMPCT_BLOCK = 4,                              //!< Defined in BIP152
@@ -524,7 +518,6 @@ public:
 
     // Single-message helper methods
     bool IsMsgTx() const { return type == MSG_TX; }
-    bool IsMsgCoinStake() const { return type == MSG_COINSTAKE; }
     bool IsMsgBlk() const { return type == MSG_BLOCK; }
     bool IsMsgStakeModifier() const { return type == MSG_STAKE_MODIFIER; }
     bool IsMsgWtx() const { return type == MSG_WTX; }
@@ -535,7 +528,7 @@ public:
     // Combined-message helper methods
     bool IsGenTxMsg() const
     {
-        return type == MSG_TX || type == MSG_WTX || type == MSG_WITNESS_TX || type == MSG_COINSTAKE;
+        return type == MSG_TX || type == MSG_WTX || type == MSG_WITNESS_TX;
     }
     bool IsGenBlkMsg() const
     {


### PR DESCRIPTION
## Summary
- drop COINSTAKE P2P message type and related handling
- simplify PoS message relay policy
- update documentation for remaining STAKEMODIFIER message

## Testing
- `cmake -S . -B build -GNinja` *(fails: libsecp256k1_zkp >= 0.6.1 not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c40a623024832ab16b58600398c3ef