### PR TITLE
Use PoS spacing for priority stake duration

### DIFF
--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -147,6 +147,10 @@ struct Params {
     uint256 posLimitLower;
     // Target spacing between staked blocks (seconds)
     int64_t nStakeTargetSpacing{8 * 60};
+    std::chrono::seconds StakeTargetSpacing() const
+    {
+        return std::chrono::seconds{nStakeTargetSpacing};
+    }
     //! Total coin supply allowed by consensus (including genesis block)
     CAmount nMaximumSupply{0};
     //! Reward paid in the genesis block (satoshis)

--- a/src/policy/priority.cpp
+++ b/src/policy/priority.cpp
@@ -22,7 +22,7 @@ int64_t GetBGDPriority(const CTransaction& tx, CAmount fee,
             int n_blocks = chain_height - static_cast<int>(coin.nHeight);
             if (n_blocks > 0) {
                 stake_duration = std::max<int64_t>(stake_duration,
-                                                   int64_t(n_blocks) * params.nPowTargetSpacing);
+                                                   int64_t(n_blocks) * params.nStakeTargetSpacing);
             }
         }
     }

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -69,6 +69,7 @@ add_executable(test_bitcoin
   policy_fee_tests.cpp
   policyestimator_tests.cpp
   pool_tests.cpp
+  priority_tests.cpp
   stake_tests.cpp
   prevector_tests.cpp
   raii_event_tests.cpp

--- a/src/test/priority_tests.cpp
+++ b/src/test/priority_tests.cpp
@@ -1,0 +1,49 @@
+#include <policy/priority.h>
+#include <coins.h>
+#include <kernel/mempool_priority.h>
+#include <txmempool.h>
+#include <util/translation.h>
+#include <test/util/setup_common.h>
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(priority_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(stake_duration_uses_pos_spacing)
+{
+    // Create an empty mempool
+    bilingual_str error;
+    CTxMemPool pool{CTxMemPool::Options{}, error};
+
+    // Setup coins view with a single coin aged n_blocks
+    CCoinsView base;
+    CCoinsViewCache view(&base);
+    const CAmount value{1000 * COIN};
+    const int chain_height{200};
+    const int coin_height{100};
+    const int n_blocks{chain_height - coin_height};
+    COutPoint prevout{Txid::FromUint256(uint256{1}), 0};
+    view.AddCoin(prevout, Coin(CTxOut(value, CScript{}), coin_height, /*coinbase=*/false), false);
+
+    // Transaction spending the coin
+    CMutableTransaction mtx;
+    mtx.vin.emplace_back(prevout);
+    mtx.vout.emplace_back(value, CScript{});
+    const CTransaction tx{mtx};
+
+    // Consensus params with differing PoW and PoS spacing
+    Consensus::Params params = Params().GetConsensus();
+    params.nPowTargetSpacing = 6000;   // Below 7-day threshold when multiplied
+    params.nStakeTargetSpacing = 7000; // Above 7-day threshold when multiplied
+
+    const int64_t expected_duration = int64_t(n_blocks) * params.nStakeTargetSpacing;
+    const int64_t expected = CalculateStakePriority(tx.GetValueOut()) +
+                             CalculateStakeDurationPriority(expected_duration);
+
+    const int64_t actual = GetBGDPriority(tx, /*fee=*/0, view, pool,
+                                          chain_height, params,
+                                          /*signals_rbf=*/false, /*has_ancestors=*/false);
+
+    BOOST_CHECK_EQUAL(expected, actual);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary
- use nStakeTargetSpacing when computing stake duration in priority
- expose stake target spacing in consensus params
- add unit test ensuring PoS spacing affects priority

## Testing
- `cmake -B build` *(fails: libsecp256k1_zkp >= 0.6.1 not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c40a1e9b90832ab6e54d5bfe334d68