### PR TITLE
test: add bulletproof value and balance validation checks

### DIFF
--- a/src/test/validation_tests.cpp
+++ b/src/test/validation_tests.cpp
@@ -15,6 +15,11 @@
 #include <validation.h>
 #include <script/script.h>
 
+#ifdef ENABLE_BULLETPROOFS
+#include <bulletproofs.h>
+#include <random.h>
+#endif
+
 #include <string>
 #include <limits>
 
@@ -372,6 +377,24 @@ BOOST_AUTO_TEST_CASE(block_malleation)
 }
 
 #ifdef ENABLE_BULLETPROOFS
+static CBulletproof MakeBulletproof(CAmount value)
+{
+    static secp256k1_context* ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    CBulletproof bp;
+    unsigned char blind[32];
+    GetRandBytes({blind, 32});
+
+    BOOST_REQUIRE(secp256k1_pedersen_commit(ctx, &bp.commitment, blind, value, &secp256k1_generator_h) == 1);
+
+    bp.proof.resize(SECP256K1_RANGE_PROOF_MAX_LENGTH);
+    size_t proof_len = bp.proof.size();
+    BOOST_REQUIRE(secp256k1_rangeproof_sign(ctx, bp.proof.data(), &proof_len, 0, &bp.commitment, blind,
+                                           nullptr, 0, 0, value, &secp256k1_generator_h) == 1);
+    bp.proof.resize(proof_len);
+    bp.extra.assign(blind, blind + 32);
+    return bp;
+}
+
 BOOST_AUTO_TEST_CASE(bulletproof_validation_tests)
 {
     // Craft transaction with a Bulletproof opcode carrying an empty proof.
@@ -401,6 +424,49 @@ BOOST_AUTO_TEST_CASE(bulletproof_validation_tests)
     TxValidationState state2;
     BOOST_CHECK(!CheckBulletproofs(tx2, state2));
     BOOST_CHECK_EQUAL(state2.GetRejectReason(), "bad-bulletproof-missing");
+
+    // Output with non-zero value should be rejected.
+    CMutableTransaction mtx3;
+    mtx3.version = CTransaction::CURRENT_VERSION | CTransaction::BULLETPROOF_VERSION;
+    mtx3.vin.emplace_back();
+    mtx3.vout.emplace_back(CAmount{1}, CScript());
+    CBulletproof bp3 = MakeBulletproof(/*value=*/1);
+    CScript bp_script3;
+    bp_script3 << OP_BULLETPROOF
+               << std::vector<unsigned char>(bp3.commitment.data,
+                                              bp3.commitment.data + sizeof(bp3.commitment.data))
+               << bp3.proof;
+    mtx3.vout[0].scriptPubKey = bp_script3;
+    const CTransaction tx3{mtx3};
+    TxValidationState state3;
+    BOOST_CHECK(!CheckBulletproofs(tx3, state3));
+    BOOST_CHECK_EQUAL(state3.GetRejectReason(), "bad-bulletproof-value");
+
+    // Imbalanced input and output commitments should be rejected.
+    CMutableTransaction mtx4;
+    mtx4.version = CTransaction::CURRENT_VERSION | CTransaction::BULLETPROOF_VERSION;
+    mtx4.vin.emplace_back();
+    CBulletproof bp_in = MakeBulletproof(/*value=*/5);
+    CScript in_script;
+    in_script << OP_BULLETPROOF
+              << std::vector<unsigned char>(bp_in.commitment.data,
+                                             bp_in.commitment.data + sizeof(bp_in.commitment.data))
+              << bp_in.proof;
+    mtx4.vin[0].scriptSig = in_script;
+
+    mtx4.vout.emplace_back(CAmount{0}, CScript());
+    CBulletproof bp_out = MakeBulletproof(/*value=*/6);
+    CScript out_script;
+    out_script << OP_BULLETPROOF
+               << std::vector<unsigned char>(bp_out.commitment.data,
+                                              bp_out.commitment.data + sizeof(bp_out.commitment.data))
+               << bp_out.proof;
+    mtx4.vout[0].scriptPubKey = out_script;
+
+    const CTransaction tx4{mtx4};
+    TxValidationState state4;
+    BOOST_CHECK(!CheckBulletproofs(tx4, state4));
+    BOOST_CHECK_EQUAL(state4.GetRejectReason(), "bad-bulletproof-balance");
 }
 
 BOOST_FIXTURE_TEST_CASE(bulletproof_activation_tests, TestChain100Setup)


### PR DESCRIPTION
## Summary
- add helper to craft valid Bulletproof proofs in unit tests
- cover non-zero output amounts and imbalanced commitments

## Testing
- `cmake -GNinja -S . -B build -DBUILD_BITCOIN_QT=OFF -DBUILD_BENCH=OFF -DBUILD_FUZZ=OFF` *(fails: libsecp256k1_zkp >= 0.6.1 not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c408be4678832a88480c922a1c2ca5