### PR TITLE
test: verify tampered bulletproof fails

### DIFF
--- a/test/rpc/test_bulletproof.py
+++ b/test/rpc/test_bulletproof.py
@@ -50,6 +50,10 @@ class BulletproofRPCTest(unittest.TestCase):
         for proof in proofs:
             verified = self.rpc_call("verifybulletproof", [proof])
             self.assertTrue(verified.get("result"))
+            # Tamper with the proof by flipping the first byte to test verification failure.
+            flipped = f"{int(proof[:2], 16) ^ 1:02x}" + proof[2:]
+            tampered = self.rpc_call("verifybulletproof", [flipped])
+            self.assertFalse(tampered.get("result"))
 
     def test_invalid_proof(self):
         # A random string should not verify as a valid Bulletproof.


### PR DESCRIPTION
## Summary
- extend bulletproof RPC test to tamper with proofs and ensure verification fails

## Testing
- `python3 test/rpc/test_bulletproof.py`


------
https://chatgpt.com/codex/tasks/task_b_68c408bca3c4832aa6dec731c8582f1b