### PR TITLE
Add dividend payout tests

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -40,6 +40,7 @@ add_executable(test_bitcoin
   denialofservice_tests.cpp
   descriptor_tests.cpp
   disconnected_transactions.cpp
+  dividend_tests.cpp
   feefrac_tests.cpp
   flatfile_tests.cpp
   fs_tests.cpp

--- a/src/test/dividend_tests.cpp
+++ b/src/test/dividend_tests.cpp
@@ -1,0 +1,48 @@
+#include <boost/test/unit_test.hpp>
+#include <dividend/dividend.h>
+#include <test/util/setup_common.h>
+
+BOOST_FIXTURE_TEST_SUITE(dividend_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(payouts_basic)
+{
+    using namespace dividend;
+    std::map<std::string, StakeInfo> stakes{
+        {"A", StakeInfo{10 * COIN, 0}},
+        {"B", StakeInfo{20 * COIN, 0}},
+    };
+    CAmount pool{100 * COIN};
+    auto payouts{CalculatePayouts(stakes, QUARTER_BLOCKS, pool)};
+    BOOST_CHECK_EQUAL(payouts.size(), 2);
+    BOOST_CHECK_EQUAL(payouts["A"], 8125000);
+    BOOST_CHECK_EQUAL(payouts["B"], 16250000);
+}
+
+BOOST_AUTO_TEST_CASE(payouts_scaled)
+{
+    using namespace dividend;
+    std::map<std::string, StakeInfo> stakes{
+        {"A", StakeInfo{10 * COIN, 0}},
+        {"B", StakeInfo{20 * COIN, 0}},
+    };
+    CAmount pool{static_cast<CAmount>(0.1 * COIN)};
+    auto payouts{CalculatePayouts(stakes, QUARTER_BLOCKS, pool)};
+    BOOST_CHECK_EQUAL(payouts["B"], 2 * payouts["A"]);
+    BOOST_CHECK_LE(std::abs(payouts["A"] + payouts["B"] - pool), 1);
+}
+
+BOOST_AUTO_TEST_CASE(no_payouts)
+{
+    using namespace dividend;
+    std::map<std::string, StakeInfo> stakes{
+        {"A", StakeInfo{10 * COIN, QUARTER_BLOCKS}},
+    };
+    auto payouts{CalculatePayouts(stakes, QUARTER_BLOCKS, 100 * COIN)};
+    BOOST_CHECK(payouts.empty());
+    payouts = CalculatePayouts(stakes, QUARTER_BLOCKS - 1, 100 * COIN);
+    BOOST_CHECK(payouts.empty());
+    payouts = CalculatePayouts(stakes, QUARTER_BLOCKS, 0);
+    BOOST_CHECK(payouts.empty());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/functional/dividend_payout.py
+++ b/test/functional/dividend_payout.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Exercise dividend payout and claiming."""
+from decimal import Decimal
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+QUARTER_BLOCKS = 16200
+
+class DividendPayoutTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.setup_clean_chain = True
+        self.extra_args = [["-dividendpayouts=1"], ["-dividendpayouts=1"]]
+
+    def run_test(self):
+        node0, node1 = self.nodes
+        addr0 = node0.getnewaddress()
+        addr1 = node1.getnewaddress()
+
+        node0.generatetoaddress(1, addr0)
+        node0.sendtoaddress(addr1, 1)
+        node0.generatetoaddress(1, addr0)
+
+        node0.startstaking()
+        node1.startstaking()
+
+        remaining = QUARTER_BLOCKS - node0.getblockcount()
+        node0.generatetoaddress(remaining, addr0)
+
+        blockhash = node0.getblockhash(QUARTER_BLOCKS)
+        block = node0.getblock(blockhash, 2)
+        reward_tx = block["tx"][1]
+        assert_equal(reward_tx["vout"][2]["value"], block["tx"][1]["vout"][2]["value"])
+
+        claim0 = node0.claimdividends(addr0)
+        claim1 = node1.claimdividends(addr1)
+        wallet_claims = node0.claimwalletdividends()
+
+        assert "claimed" in claim0
+        assert "claimed" in claim1
+        assert isinstance(wallet_claims, dict)
+
+if __name__ == '__main__':
+    DividendPayoutTest().main()


### PR DESCRIPTION
## Summary
- exercise dividend payout calculations with varying weights and pools
- add functional test scaffolding for dividend payout claims

## Testing
- `make check` *(fails: No rule to make target 'check')*
- `test/functional/test_runner.py dividend_payout.py` *(fails: config.ini missing)*

------
https://chatgpt.com/codex/tasks/task_b_68c42bc6a444832aa133d1f0302dd47a