### PR TITLE
ci: test signet block acceptance

### DIFF
--- a/ci/test/04_bootstrap_fresh_testnet.sh
+++ b/ci/test/04_bootstrap_fresh_testnet.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
-# Simple smoke test that a new signet instance can be bootstrapped.
+# Simple smoke test that a new signet instance can be bootstrapped and
+# accepts a block solving the signet challenge.
 
 set -e
 
@@ -8,7 +9,16 @@ DATADIR="${BASE_SCRATCH_DIR}/signet-bootstrap"
 rm -rf "$DATADIR"
 mkdir -p "$DATADIR"
 
-"${BASE_OUTDIR}/bin/bitgoldd" -signet -datadir="$DATADIR" -daemon
+"${BASE_OUTDIR}/bin/bitgoldd" --signet --signetchallenge=51 -datadir="$DATADIR" -daemon
 
-"${BASE_OUTDIR}/bin/bitgold-cli" -signet -datadir="$DATADIR" -rpcwait getblockchaininfo > /dev/null
-"${BASE_OUTDIR}/bin/bitgold-cli" -signet -datadir="$DATADIR" stop > /dev/null
+# Wait for the node to be ready
+"${BASE_OUTDIR}/bin/bitgold-cli" --signet --signetchallenge=51 -datadir="$DATADIR" -rpcwait getblockchaininfo > /dev/null
+
+# Generate a block using the signet challenge and submit it
+BLOCK_HEX=$("${BASE_OUTDIR}/bin/bitgold-cli" --signet --signetchallenge=51 -datadir="$DATADIR" generateblock "raw(51)" '[]' false | jq -r '.hex')
+"${BASE_OUTDIR}/bin/bitgold-cli" --signet --signetchallenge=51 -datadir="$DATADIR" submitblock "$BLOCK_HEX" > /dev/null
+
+# Ensure the block was accepted
+test "$("${BASE_OUTDIR}/bin/bitgold-cli" --signet --signetchallenge=51 -datadir="$DATADIR" getblockcount)" -eq 1
+
+"${BASE_OUTDIR}/bin/bitgold-cli" --signet --signetchallenge=51 -datadir="$DATADIR" stop > /dev/null


### PR DESCRIPTION
## Summary
- exercise the signet chain in CI by generating and submitting a block with an OP_TRUE challenge

## Testing
- `bash ci/test/04_bootstrap_fresh_testnet.sh` *(fails: /bin/bitgoldd: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_b_68c42d4ce3e4832a9b5620b0d0fdc6da