### PR TITLE
ci: run fuzz tests with sanitizers

### DIFF
--- a/ci/test/00_setup_env_native_fuzz.sh
+++ b/ci/test/00_setup_env_native_fuzz.sh
@@ -18,7 +18,7 @@ export GOAL="all"
 export CI_CONTAINER_CAP="--cap-add SYS_PTRACE"  # If run with (ASan + LSan), the container needs access to ptrace (https://github.com/google/sanitizers/issues/764)
 export BITCOIN_CONFIG="\
  -DBUILD_FOR_FUZZING=ON \
- -DSANITIZERS=fuzzer,address,undefined,float-divide-by-zero,integer \
+ --enable-sanitizers=fuzzer,address,undefined,float-divide-by-zero,integer \
  -DCMAKE_C_COMPILER=clang-${APT_LLVM_V} \
  -DCMAKE_CXX_COMPILER=clang++-${APT_LLVM_V} \
  -DCMAKE_C_FLAGS='-ftrivial-auto-var-init=pattern' \

--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -8,10 +8,10 @@ export LC_ALL=C.UTF-8
 
 set -ex
 
-export ASAN_OPTIONS="detect_leaks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1"
-export LSAN_OPTIONS="suppressions=${BASE_ROOT_DIR}/test/sanitizer_suppressions/lsan"
+export ASAN_OPTIONS="detect_leaks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1:halt_on_error=1:abort_on_error=1:exitcode=1"
+export LSAN_OPTIONS="suppressions=${BASE_ROOT_DIR}/test/sanitizer_suppressions/lsan:exitcode=1"
 export TSAN_OPTIONS="suppressions=${BASE_ROOT_DIR}/test/sanitizer_suppressions/tsan:halt_on_error=1:second_deadlock_stack=1"
-export UBSAN_OPTIONS="suppressions=${BASE_ROOT_DIR}/test/sanitizer_suppressions/ubsan:print_stacktrace=1:halt_on_error=1:report_error_type=1"
+export UBSAN_OPTIONS="suppressions=${BASE_ROOT_DIR}/test/sanitizer_suppressions/ubsan:print_stacktrace=1:halt_on_error=1:report_error_type=1:exitcode=1"
 
 echo "Number of available processing units: $(nproc)"
 if [ "$CI_OS_NAME" == "macos" ]; then
@@ -122,7 +122,7 @@ if [[ "${RUN_TIDY}" == "true" ]]; then
   BITCOIN_CONFIG_ALL="$BITCOIN_CONFIG_ALL -DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
 fi
 
-bash -c "cmake -S $BASE_ROOT_DIR -B ${BASE_BUILD_DIR} $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG || ( (cat $(cmake -P "${BASE_ROOT_DIR}/ci/test/GetCMakeLogFiles.cmake")) && false)"
+bash -c "\"${BASE_ROOT_DIR}/configure\" -S $BASE_ROOT_DIR -B ${BASE_BUILD_DIR} $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG || ((cat $(cmake -P "${BASE_ROOT_DIR}/ci/test/GetCMakeLogFiles.cmake")) && false)"
 
 # shellcheck disable=SC2086
 cmake --build "${BASE_BUILD_DIR}" "$MAKEJOBS" --target all $GOAL || (

--- a/configure
+++ b/configure
@@ -3,6 +3,11 @@
 set -e
 ARGS=""
 for arg in "$@"; do
+  case "$arg" in
+    --enable-sanitizers=*)
+      arg="-DSANITIZERS=${arg#*=}"
+      ;;
+  esac
   ARGS="$ARGS $arg"
 done
 cmake $ARGS

--- a/doc/fuzzing.md
+++ b/doc/fuzzing.md
@@ -21,6 +21,19 @@ See [further](#run-without-sanitizers-for-increased-throughput) for more informa
 There is also a runner script to execute all fuzz targets. Refer to
 `./build_fuzz/test/fuzz/test_runner.py --help` for more details.
 
+## Running with sanitizers
+
+The continuous integration job builds the fuzz targets with sanitizers enabled
+and aborts on any findings. To reproduce this setup locally:
+
+```sh
+$ ./configure -B build --enable-sanitizers=fuzzer,address,undefined,float-divide-by-zero,integer -DBUILD_FOR_FUZZING=ON
+$ cmake --build build
+$ test/fuzz/test_runner.py --empty_min_time=60 path/to/corpus
+```
+
+Any sanitizer report will cause the process to exit with a non-zero status.
+
 ## Overview of Bitcoin Core fuzzing
 
 [Google](https://github.com/google/fuzzing/) has a good overview of fuzzing in general, with contributions from key architects of some of the most-used fuzzers. [This paper](https://agroce.github.io/bitcoin_report.pdf) includes an external overview of the status of Bitcoin Core fuzzing, as of summer 2021.  [John Regehr](https://blog.regehr.org/archives/1687) provides good advice on writing code that assists fuzzers in finding bugs, which is useful for developers to keep in mind.


### PR DESCRIPTION
## Summary
- configure: map --enable-sanitizers to CMake
- run fuzz CI with sanitizers enabled and abort on sanitizer issues
- document how to run sanitized fuzz targets locally

## Testing
- `./ci/lint_run.sh` *(fails: Please document the following arguments: {'-stakesplitthreshold'}; pyenv: version `3.10.14` is not installed; ruff: command not found; src/crc32c is not a subtree)*

------
https://chatgpt.com/codex/tasks/task_b_68c42d51a150832ab8334278f065b217