### PR TITLE
Add regtest block validation benchmark and hardware requirements note

### DIFF
--- a/contrib/bench/block_validation_bench.py
+++ b/contrib/bench/block_validation_bench.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""Benchmark validation of ~20 MB blocks on regtest."""
+
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'test', 'functional'))
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.wallet import MiniWallet
+from test_framework.util import create_lots_of_big_transactions, gen_return_txouts
+
+
+class BlockValidationBench(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        target_weight = 20_000_000
+        self.extra_args = [
+            [f"-blockmaxweight={target_weight}"],
+            [f"-blockmaxweight={target_weight}"],
+        ]
+
+    def run_test(self):
+        node0, node1 = self.nodes
+        mini_wallet = MiniWallet(node0)
+        mini_wallet.generate(500)
+        self.sync_blocks()
+
+        txouts = gen_return_txouts()
+        fee = 100 * node0.getnetworkinfo()["relayfee"]
+        approx_tx_size = 200 + sum(len(txout.serialize()) for txout in txouts)
+        tx_count = int(20_000_000 // approx_tx_size + 1)
+        self.log.info(f"Creating {tx_count} large transactions")
+        create_lots_of_big_transactions(mini_wallet, node0, fee, tx_count, txouts)
+
+        self.disconnect_nodes(0, 1)
+        block_hash = self.generate(node0, 1)[0]
+        block_hex = node0.getblock(block_hash, 0)
+
+        start = time.time()
+        node1.submitblock(block_hex)
+        elapsed = time.time() - start
+        self.log.info(f"Validation time: {elapsed:.2f}s")
+
+
+if __name__ == "__main__":
+    BlockValidationBench().main()

--- a/doc/operating-notes.md
+++ b/doc/operating-notes.md
@@ -7,3 +7,14 @@ This document summarizes default limits enforced by the node.
 - **Mempool size**: Defaults to 500&nbsp;MB for normal operation. When running with `-blocksonly`, the mempool is limited to 8&nbsp;MB.
 
 These limits are reflected in the sample configuration files and operator guidance. See [`doc/bitcoin-conf.md`](bitcoin-conf.md) and the example configs in [`doc/examples`](examples) for details.
+
+## Hardware requirements
+
+Running a full node with the default policy limits typically requires:
+
+- **CPU**: 2 or more cores.
+- **Memory**: At least 2&nbsp;GB of RAM.
+- **Disk**: Around 1&nbsp;TB of free disk space.
+- **Network**: A reliable broadband connection with at least 1&nbsp;MB/s upload speed.
+
+Actual requirements vary with network conditions and optional indexes.


### PR DESCRIPTION
## Summary
- add `block_validation_bench.py` to measure validation time of ~20 MB blocks on regtest
- document typical hardware requirements in `operating-notes.md`

## Testing
- `python3 test/lint/lint-python.py` *(fails: Missing positional argument "test_file" in various wallet and mempool tests)*
- `python3 test/lint/lint-python-dead-code.py`
- `python3 test/lint/lint-python-utf8-encoding.py`
- `python3 test/lint/lint-spelling.py`
- `python3 test/lint/check-doc.py` *(fails: '-stakesplitthreshold' missing documentation)*
- `python3 test/lint/lint-files.py` *(fails: several test files lack executable permissions)*

------
https://chatgpt.com/codex/tasks/task_b_68c42d52cf60832aba183f83ea50651d