### PR TITLE
docs: add staking RPC examples

### DIFF
--- a/doc/rpc/staking.md
+++ b/doc/rpc/staking.md
@@ -1,0 +1,86 @@
+# Staking RPC examples
+
+This document shows how to use RPC calls related to staking and dividends.
+
+## `getstakinginfo`
+
+Returns whether staking is enabled and if the wallet is currently staking.
+
+```
+$ bitcoin-cli getstakinginfo
+{
+  "enabled": true,
+  "staking": false
+}
+```
+
+## `setreservebalance`
+
+Reserves a portion of the wallet balance from staking. Call with no
+parameters to return the current amount.
+
+```
+$ bitcoin-cli setreservebalance true 100
+{
+  "reserved": 100.00000000
+}
+```
+
+## `reservebalance`
+
+Deprecated alias for `setreservebalance`.
+
+```
+$ bitcoin-cli reservebalance
+{
+  "reserved": 100.00000000
+}
+```
+
+## `setstakesplitthreshold`
+
+Sets the minimum amount before a staking output is split. Setting the value
+to `0` disables splitting.
+
+```
+$ bitcoin-cli setstakesplitthreshold 50
+{
+  "threshold": 50.00000000
+}
+```
+
+## `getdividendinfo`
+
+Displays the dividend pool, stake information, and snapshots.
+
+```
+$ bitcoin-cli getdividendinfo
+{
+  "pool": "12.50000000",
+  "stakes": {
+    "addr": {
+      "weight": "100.00000000",
+      "last_payout": 100,
+      "pending": "0.25000000"
+    }
+  },
+  "snapshots": {
+    "100": {
+      "addr": "100.00000000"
+    }
+  }
+}
+```
+
+## `claimdividends`
+
+Claims matured dividends for an address. Dividend payouts must be enabled
+with `-dividendpayouts`.
+
+```
+$ bitcoin-cli claimdividends "addr"
+{
+  "claimed": "0.25000000",
+  "remaining": "12.25000000"
+}
+```

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -3400,7 +3400,7 @@ static RPCHelpMan getdividendinfo()
 {
     return RPCHelpMan{
         "getdividendinfo",
-        "Returns information about the dividend pool and stakes.",
+        "Returns information about the dividend pool, current stakes, and stake snapshots.",
         {},
         RPCResult{RPCResult::Type::OBJ, "", "", {
             {RPCResult::Type::STR_AMOUNT, "pool", "Current dividend pool"},
@@ -3409,6 +3409,7 @@ static RPCHelpMan getdividendinfo()
                 {RPCResult::Type::NUM, "last_payout", "Height of last payout"},
                 {RPCResult::Type::STR_AMOUNT, "pending", "Pending dividend amount"},
             }}}},
+            {RPCResult::Type::OBJ, "snapshots", "Stake weight snapshots by height"},
         }},
         RPCExamples{HelpExampleCli("getdividendinfo", "") + HelpExampleRpc("getdividendinfo", "")},
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
@@ -3445,7 +3446,7 @@ static RPCHelpMan claimdividends()
 {
     return RPCHelpMan{
         "claimdividends",
-        "Claim pending dividends for an address.",
+        "Claim pending dividends for an address. Requires -dividendpayouts to be enabled.",
         {
             {"address", RPCArg::Type::STR, RPCArg::Optional::NO, "Address to claim for"},
         },

--- a/src/rpc/dividend.cpp
+++ b/src/rpc/dividend.cpp
@@ -31,11 +31,11 @@ static RPCHelpMan claimdividends()
 {
     return RPCHelpMan{
         "claimdividends",
-        "Claim pending dividends for an address.",
+        "Claim pending dividends for an address. Requires -dividendpayouts to be enabled.",
         {
             {"address", RPCArg::Type::STR, RPCArg::Optional::NO, "address claiming dividends"},
         },
-        RPCResult{RPCResult::Type::OBJ, "", "", {{RPCResult::Type::AMOUNT, "claimed", "amount claimed"}, {RPCResult::Type::AMOUNT, "remaining", "remaining pool"}}},
+        RPCResult{RPCResult::Type::OBJ, "", "", {{RPCResult::Type::STR_AMOUNT, "claimed", "amount claimed"}, {RPCResult::Type::STR_AMOUNT, "remaining", "remaining pool"}}},
         RPCExamples{HelpExampleCli("claimdividends", "\"addr\"") + HelpExampleRpc("claimdividends", "[\"addr\"]")},
         [](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
             if (!gArgs.GetBoolArg("-dividendpayouts", false)) {

--- a/src/rpc/staking.cpp
+++ b/src/rpc/staking.cpp
@@ -47,7 +47,8 @@ static RPCHelpMan setreservebalance()
 {
     return RPCHelpMan{
         "setreservebalance",
-        "Set or get the reserve balance that will not be used for staking.",
+        "Set or get the wallet balance that will not be used for staking.\n"
+        "Without arguments, the current reserved amount is returned.",
         {
             {"reserve", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED, "true to reserve balance, false to disable reserve"},
             {"amount", RPCArg::Type::AMOUNT, RPCArg::Optional::OMITTED, "amount in BGD to reserve"},
@@ -83,7 +84,8 @@ static RPCHelpMan reservebalance()
 {
     return RPCHelpMan{
         "reservebalance",
-        "Deprecated alias for setreservebalance.",
+        "Deprecated alias for setreservebalance.\n"
+        "Provided for backward compatibility.",
         {
             {"reserve", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED, "true to reserve balance, false to disable reserve"},
             {"amount", RPCArg::Type::AMOUNT, RPCArg::Optional::OMITTED, "amount in BGD to reserve"},
@@ -99,7 +101,7 @@ static RPCHelpMan getstakinginfo()
 {
     return RPCHelpMan{
         "getstakinginfo",
-        "Returns the staking status for this wallet.\n",
+        "Alias for getstakingstatus. Returns the staking status for this wallet.\n",
         {},
         RPCResult{
             RPCResult::Type::OBJ, "", "", {
@@ -116,7 +118,8 @@ static RPCHelpMan setstakesplitthreshold()
 {
     return RPCHelpMan{
         "setstakesplitthreshold",
-        "Set or get the stake split threshold.",
+        "Set or get the stake split threshold. Outputs above this amount are\n"
+        "split when staking to keep stakes small. Set to 0 to disable.\n",
         {{"amount", RPCArg::Type::AMOUNT, RPCArg::Optional::OMITTED, "threshold in BGD"}},
         RPCResult{RPCResult::Type::OBJ, "", "", {{RPCResult::Type::NUM, "threshold", "current threshold"}}},
         RPCExamples{HelpExampleCli("setstakesplitthreshold", "100") + HelpExampleRpc("setstakesplitthreshold", "50")},


### PR DESCRIPTION
## Summary
- clarify staking and dividend RPC help text
- document usage examples for staking RPCs

## Testing
- `test/functional/test_runner.py wallet_staking_toggle.py` *(fails: No such file or directory: '/workspace/bitcoin/test/functional/../config.ini')*
- `cmake -B build -G Ninja` *(fails: libsecp256k1_zkp >= 0.6.1 not found)*
- `python3 test/lint/check-doc.py doc/rpc/staking.md` *(fails: Please document the following arguments: {'-stakesplitthreshold'})*


------
https://chatgpt.com/codex/tasks/task_b_68c42d54f430832aa0e617dd4d5e456b