### PR TITLE
docs: add BitGold Guix build notes

### DIFF
--- a/contrib/guix/README.md
+++ b/contrib/guix/README.md
@@ -64,6 +64,20 @@ following from the top of a clean repository:
 ./contrib/guix/guix-build
 ```
 
+### Building BitGold
+
+Projects based on Bitcoin Core can leverage these scripts as well.  To build
+the BitGold variant, enable the `BITGOLD` environment variable prior to
+invoking the build script:
+
+```sh
+export BITGOLD=1
+./contrib/guix/guix-build
+```
+
+The resulting artifacts will be tagged with the BitGold name while retaining
+the same reproducible Guix toolchain.
+
 ## Codesigning build outputs
 
 The `guix-codesign` command attaches codesignatures (produced by codesigners) to


### PR DESCRIPTION
## Summary
- document how to trigger BitGold-specific builds via Guix

## Testing
- `guix build hello`
- `env -i HOME=$HOME PATH=$PATH /usr/bin/guix build hello`
- `sha256sum /gnu/store/s5pd3rnzymliafb4la5sca63j86xs0y0-hello-2.12.1/bin/hello`


------
https://chatgpt.com/codex/tasks/task_b_68c42d571c70832a94fd1c02c288b14f