### PR TITLE
Add wallet blinding functional test and document RPCs

### DIFF
--- a/doc/bulletproofs.md
+++ b/doc/bulletproofs.md
@@ -57,6 +57,15 @@ Two RPC methods expose the Bulletproof functionality:
     returned from `createrawbulletprooftransaction` can be checked
     individually with this RPC.
 
+Additional wallet RPCs simplify using confidential transactions:
+
+* `getnewshieldedaddress`
+  – Returns a new shielded address that commits to amounts with Bulletproofs.
+* `sendshielded address amount`
+  – Sends funds to a shielded address using confidential commitments.
+  Wallets restoring from backup must run `rescanblockchain` to reveal
+  balances for blinded outputs.
+
 Both methods are available through `bitgold-cli` when BitGold is
 compiled with Bulletproof support.  Wallets can also create Bulletproof
 transactions using standard RPCs such as `sendtoaddress` once the feature

--- a/test/functional/wallet_blinding.py
+++ b/test/functional/wallet_blinding.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Test wallet balance after unblinding confidential transactions."""
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+class WalletBlindingTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.extra_args = [[]]
+
+    def run_test(self):
+        node = self.nodes[0]
+        node.generate(101)
+        blinded = node.getnewshieldedaddress()
+        node.sendshielded(blinded, 1)
+        node.generate(1)
+        assert_equal(node.getbalance(), 0)
+        node.rescanblockchain()
+        assert_equal(node.getbalance(), 1)
+
+if __name__ == '__main__':
+    WalletBlindingTest(__file__).main()


### PR DESCRIPTION
## Summary
- test wallet blinding behavior with rescan and unblinding
- document shielded address wallet RPCs for bulletproof usage

## Testing
- `cmake -S . -B build -G "Unix Makefiles"` *(fails: Package 'libsecp256k1_zkp' has version '0.1.0-dev', required '>= 0.6.1')*

------
https://chatgpt.com/codex/tasks/task_b_68c42d481658832ab6af2cd112a91da8