### PR TITLE
test: check address prefixes

### DIFF
--- a/test/functional/address_prefixes.py
+++ b/test/functional/address_prefixes.py
@@ -38,6 +38,10 @@ class AddressPrefixesTest(BitcoinTestFramework):
         script_addr = node.getnewaddress(address_type='p2sh-segwit')
         assert script_addr[0] == 'G'
 
+        # Bech32 address
+        bech32_addr = node.getnewaddress("", "bech32")
+        assert bech32_addr.startswith('bg1')
+
         # Dump private key and verify secret key prefix
         wif = node.dumpprivkey(legacy_addr)
         decoded = b58decode(wif)


### PR DESCRIPTION
## Summary
- test address prefixes for legacy, P2SH-SegWit, and Bech32 addresses
- verify WIF secret key version byte

## Testing
- `test/functional/test_runner.py -f address_prefixes.py` *(fails: No functional tests to run. Re-compile with the -DBUILD_DAEMON=ON build option)*
- `cmake -B build -DBUILD_DAEMON=ON` *(fails: Could not find Boost package)*

------
https://chatgpt.com/codex/tasks/task_b_68c43e988748832ab9bdcce973e0cca2