### PR TITLE
test: add PoS supply cap functional test

### DIFF
--- a/test/functional/pos_supply_cap.py
+++ b/test/functional/pos_supply_cap.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Verify staking supply cap and halving schedule."""
+
+from decimal import Decimal
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.messages import COIN
+from test_framework.util import assert_equal
+
+class PosSupplyCapTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.rpc_timeout = 120
+
+    def run_test(self):
+        node = self.nodes[0]
+        addr = node.getnewaddress()
+        for _ in range(50):
+            node.generatetoaddress(1000, addr)
+        node.generatetoaddress(1, addr)
+
+        # Check subsidy before and after the halving boundary at height 50_000
+        subsidy_before = node.getblockstats(50_000)["subsidy"]
+        subsidy_after = node.getblockstats(50_001)["subsidy"]
+        assert_equal(subsidy_before, 50 * COIN)
+        assert_equal(subsidy_after, 25 * COIN)
+
+        # Verify total minted coins including genesis do not exceed 8M
+        utxo_info = node.gettxoutsetinfo()
+        total_amount = utxo_info["total_amount"]
+        expected = Decimal(3_000_000 + 50_000 * 50 + 25)
+        assert_equal(total_amount, expected)
+        assert total_amount <= Decimal(8_000_000)
+
+if __name__ == '__main__':
+    PosSupplyCapTest(__file__).main()


### PR DESCRIPTION
## Summary
- add a regtest functional test checking PoS block subsidy halving at height 50k
- assert total issued coins including genesis stay under the 8 million cap

## Testing
- `python3 test/functional/pos_supply_cap.py --configfile=../config.ini.in` *(fails: FileNotFoundError: '@abs_top_builddir@/bin/bitgoldd@EXEEXT@')*

------
https://chatgpt.com/codex/tasks/task_b_68c447ec8008832a9bdb4230551ca194