### PR TITLE
Use RAII wrapper for Bulletproof context

### DIFF
--- a/src/bulletproofs.h
+++ b/src/bulletproofs.h
@@ -11,6 +11,7 @@ extern "C" {
 }
 #include <cstring>
 #include <serialize.h>
+#include <util/secp256k1_context.h>
 #endif
 
 struct CBulletproof {
@@ -44,11 +45,11 @@ inline bool VerifyBulletproof(const CBulletproof& proof)
 #ifdef ENABLE_BULLETPROOFS
     if (proof.proof.empty() || proof.proof.size() > SECP256K1_RANGE_PROOF_MAX_LENGTH) return false;
 
-    static secp256k1_context* ctx = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
+    static const secp256k1_context_holder ctx(SECP256K1_CONTEXT_NONE);
 
     uint64_t min_value = 0, max_value = 0;
     const unsigned char* extra = proof.extra.empty() ? nullptr : proof.extra.data();
-    int ret = secp256k1_rangeproof_verify(ctx, &min_value, &max_value, &proof.commitment,
+    int ret = secp256k1_rangeproof_verify(ctx.get(), &min_value, &max_value, &proof.commitment,
                                           proof.proof.data(), proof.proof.size(),
                                           extra, proof.extra.size(), secp256k1_generator_h);
     if (ret != 1) return false;

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(test_bitcoin
   blockmanager_tests.cpp
   bloom_tests.cpp
   bswap_tests.cpp
+  bulletproof_tests.cpp
   chainstate_write_tests.cpp
   checkqueue_tests.cpp
   cluster_linearize_tests.cpp

--- a/src/test/bulletproof_tests.cpp
+++ b/src/test/bulletproof_tests.cpp
@@ -1,0 +1,47 @@
+#include <test/util/setup_common.h>
+#include <boost/test/unit_test.hpp>
+
+#ifdef ENABLE_BULLETPROOFS
+#include <bulletproofs.h>
+#include <random.h>
+#include <util/secp256k1_context.h>
+#endif
+
+BOOST_FIXTURE_TEST_SUITE(bulletproof_tests, BasicTestingSetup)
+
+#ifdef ENABLE_BULLETPROOFS
+static CBulletproof MakeBulletproof(CAmount value)
+{
+    static const secp256k1_context_holder ctx(SECP256K1_CONTEXT_SIGN);
+    CBulletproof bp;
+    unsigned char blind[32];
+    GetRandBytes({blind, 32});
+    BOOST_REQUIRE(secp256k1_pedersen_commit(ctx.get(), &bp.commitment, blind, value, &secp256k1_generator_h) == 1);
+    bp.proof.resize(SECP256K1_RANGE_PROOF_MAX_LENGTH);
+    size_t proof_len = bp.proof.size();
+    BOOST_REQUIRE(secp256k1_rangeproof_sign(ctx.get(), bp.proof.data(), &proof_len, 0, &bp.commitment, blind,
+                                           nullptr, 0, 0, value, &secp256k1_generator_h) == 1);
+    bp.proof.resize(proof_len);
+    bp.extra.assign(blind, blind + 32);
+    return bp;
+}
+#endif
+
+BOOST_AUTO_TEST_CASE(verify_bulletproof)
+{
+#ifdef ENABLE_BULLETPROOFS
+    CBulletproof bp = MakeBulletproof(/*value=*/0);
+    for (int i = 0; i < 10; ++i) {
+        BOOST_CHECK(VerifyBulletproof(bp));
+    }
+    CBulletproof bad = bp;
+    bad.proof[0] ^= 1;
+    for (int i = 0; i < 10; ++i) {
+        BOOST_CHECK(!VerifyBulletproof(bad));
+    }
+#else
+    BOOST_TEST_MESSAGE("Bulletproofs disabled, skipping test");
+#endif
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/util/secp256k1_context.h
+++ b/src/util/secp256k1_context.h
@@ -1,5 +1,5 @@
-#ifndef BITCOIN_WALLET_SECP256K1_CONTEXT_H
-#define BITCOIN_WALLET_SECP256K1_CONTEXT_H
+#ifndef BITCOIN_UTIL_SECP256K1_CONTEXT_H
+#define BITCOIN_UTIL_SECP256K1_CONTEXT_H
 
 #include <secp256k1.h>
 
@@ -17,4 +17,4 @@ public:
     secp256k1_context* get() const { return m_ctx; }
 };
 
-#endif // BITCOIN_WALLET_SECP256K1_CONTEXT_H
+#endif // BITCOIN_UTIL_SECP256K1_CONTEXT_H

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -72,7 +72,7 @@
 
 #ifdef ENABLE_BULLETPROOFS
 #include <bulletproofs.h>
-#include <wallet/secp256k1_context.h>
+#include <util/secp256k1_context.h>
 #endif
 
 #include <algorithm>

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -9,7 +9,7 @@
 
 #ifdef ENABLE_BULLETPROOFS
 #include <bulletproofs.h>
-#include <wallet/secp256k1_context.h>
+#include <util/secp256k1_context.h>
 #endif
 
 #include <addresstype.h>


### PR DESCRIPTION
## Summary
- add reusable `secp256k1_context_holder` RAII wrapper in util
- manage Bulletproof verification context with RAII for thread-safe cleanup
- add unit test covering valid and invalid Bulletproof verification

## Testing
- `cmake -S . -B build` *(fails: libsecp256k1_zkp >= 0.6.1 not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c44a35df8c832a977721b561d20e69