### PR TITLE
Update halving interval and add long‑range supply cap test

### DIFF
--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -88,7 +88,7 @@ public:
         m_chain_type = ChainType::MAIN;
         consensus.signet_blocks = false;
         consensus.signet_challenge.clear();
-        consensus.nSubsidyHalvingInterval = 50000;
+        consensus.nSubsidyHalvingInterval = 50'000;
         consensus.script_flag_exceptions.emplace( // BIP16 exception
             uint256{"00000000000002dc756eebf4f49723ed8d30cc28a5f108eb94b1ba88ac4f9c22"}, SCRIPT_VERIFY_NONE);
         consensus.script_flag_exceptions.emplace( // Taproot exception
@@ -244,7 +244,7 @@ public:
         m_chain_type = ChainType::TESTNET;
         consensus.signet_blocks = false;
         consensus.signet_challenge.clear();
-        consensus.nSubsidyHalvingInterval = 50000;
+        consensus.nSubsidyHalvingInterval = 50'000;
         consensus.script_flag_exceptions.emplace( // BIP16 exception
             uint256{"00000000dd30457c001f4095d208cc1296b0eed002427aa599874af7a432b105"}, SCRIPT_VERIFY_NONE);
         consensus.BIP34Height = 21111;
@@ -366,7 +366,7 @@ public:
         m_chain_type = ChainType::TESTNET4;
         consensus.signet_blocks = false;
         consensus.signet_challenge.clear();
-        consensus.nSubsidyHalvingInterval = 50000;
+        consensus.nSubsidyHalvingInterval = 50'000;
         consensus.BIP34Height = 21111;
         consensus.BIP34Hash = uint256{"0000000023b3a96d3484e5abb3755c413e7d41500f8e2a5c3f0dd01299cd8ef8"};
         consensus.BIP65Height = 581885;          // 00000000007f6655f22f98e72ed80d8b06dc761d5da09df0fa1dc4be4f861eb6
@@ -521,7 +521,7 @@ public:
         m_chain_type = ChainType::SIGNET;
         consensus.signet_blocks = true;
         consensus.signet_challenge.assign(bin.begin(), bin.end());
-        consensus.nSubsidyHalvingInterval = 50000;
+        consensus.nSubsidyHalvingInterval = 50'000;
         consensus.BIP34Height = 1;
         consensus.BIP34Hash = uint256{};
         consensus.BIP65Height = 1;
@@ -623,7 +623,7 @@ public:
         m_chain_type = ChainType::REGTEST;
         consensus.signet_blocks = false;
         consensus.signet_challenge.clear();
-        consensus.nSubsidyHalvingInterval = 50000;
+        consensus.nSubsidyHalvingInterval = 50'000;
         consensus.BIP34Height = 1; // Always active unless overridden
         consensus.BIP34Hash = uint256();
         consensus.BIP65Height = 1;  // Always active unless overridden

--- a/test/functional/pos_supply_cap.py
+++ b/test/functional/pos_supply_cap.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Verify staking supply cap and halving schedule."""
+"""Verify staking supply cap and halving schedule over 100k blocks."""
 
 from decimal import Decimal
 
@@ -15,20 +15,25 @@ class PosSupplyCapTest(BitcoinTestFramework):
     def run_test(self):
         node = self.nodes[0]
         addr = node.getnewaddress()
-        for _ in range(50):
+        for _ in range(100):
             node.generatetoaddress(1000, addr)
         node.generatetoaddress(1, addr)
 
-        # Check subsidy before and after the halving boundary at height 50_000
-        subsidy_before = node.getblockstats(50_000)["subsidy"]
-        subsidy_after = node.getblockstats(50_001)["subsidy"]
-        assert_equal(subsidy_before, 50 * COIN)
-        assert_equal(subsidy_after, 25 * COIN)
+        # Check subsidy before and after the halving boundaries at heights
+        # 50_000 and 100_000
+        subsidy_50k = node.getblockstats(50_000)["subsidy"]
+        subsidy_50k1 = node.getblockstats(50_001)["subsidy"]
+        subsidy_100k = node.getblockstats(100_000)["subsidy"]
+        subsidy_100k1 = node.getblockstats(100_001)["subsidy"]
+        assert_equal(subsidy_50k, 50 * COIN)
+        assert_equal(subsidy_50k1, 25 * COIN)
+        assert_equal(subsidy_100k, 25 * COIN)
+        assert_equal(subsidy_100k1, 25 * COIN // 2)
 
         # Verify total minted coins including genesis do not exceed 8M
         utxo_info = node.gettxoutsetinfo()
         total_amount = utxo_info["total_amount"]
-        expected = Decimal(3_000_000 + 50_000 * 50 + 25)
+        expected = Decimal(3_000_000 + 50_000 * 50 + 50_000 * 25) + Decimal("12.5")
         assert_equal(total_amount, expected)
         assert total_amount <= Decimal(8_000_000)
 


### PR DESCRIPTION
## Summary
- ensure all networks use a 50k block subsidy halving interval
- extend staking supply cap test to mine over 100k blocks and check successive halvings

## Testing
- `cmake -S . -B build -GNinja` *(fails: libsecp256k1_zkp >= 0.6.1 not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c44bb283ac832a879350241e3cbc70