### PR TITLE
Adjust pruning height for mainnet and add test

### DIFF
--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -155,7 +155,7 @@ public:
         pchMessageStart[2] = 0xc5;
         pchMessageStart[3] = 0xdb;
         nDefaultPort = 8888;
-        nPruneAfterHeight = 100'000;
+        nPruneAfterHeight = 100000;
         m_assumed_blockchain_size = 720; // MB
         m_assumed_chain_state_size = 14; // MB
 

--- a/test/functional/feature_prune_height.py
+++ b/test/functional/feature_prune_height.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Verify pruning occurs once the chain passes the configured height."""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_greater_than_or_equal, assert_raises_rpc_error
+from test_framework.wallet import MiniWallet
+
+class FeaturePruneHeightTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.extra_args = [["-fastprune", "-prune=1"]]
+
+    def run_test(self):
+        node = self.nodes[0]
+        wallet = MiniWallet(node)
+        prune_after_height = 100  # Regtest prune height when -fastprune is enabled
+
+        # Mine enough blocks so that pruning can take place once the target is
+        # reached: nPruneAfterHeight + MIN_BLOCKS_TO_KEEP + 1
+        self.generate(wallet, 101)  # make mature coins for transactions
+        self.generate(node, prune_after_height + 288 - 101, sync_fun=self.no_op)
+
+        old_block = node.getblockhash(1)
+
+        # Create large blocks to exceed the prune target quickly
+        annex = b"\x50" + b"\xff" * 1_000_000
+        for _ in range(2):
+            tx = wallet.create_self_transfer()["tx"]
+            tx.wit.vtxinwit[0].scriptWitness.stack.append(annex)
+            self.generateblock(node, [tx.serialize().hex()], sync_fun=self.no_op)
+            wallet.scan_tx(node.decoderawtransaction(tx.serialize().hex()))
+
+        self.wait_until(lambda: node.getblockchaininfo()["pruneheight"] > 0)
+        info = node.getblockchaininfo()
+        assert_greater_than_or_equal(info["pruneheight"], prune_after_height)
+        assert_raises_rpc_error(-32100, "Block not available (pruned data)",
+                               node.getblock, old_block)
+
+if __name__ == '__main__':
+    FeaturePruneHeightTest(__file__).main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -117,6 +117,7 @@ BASE_SCRIPTS = [
     'wallet_basic.py',
     'address_prefixes.py',
     'feature_maxtipage.py',
+    'feature_prune_height.py',
     'wallet_multiwallet.py',
     'wallet_multiwallet.py --usecli',
     'p2p_dns_seeds.py',


### PR DESCRIPTION
## Summary
- set mainnet `nPruneAfterHeight` to 100000
- add functional test ensuring a pruned node prunes once past the configured height
- register new test in runner

## Testing
- `python3 test/functional/feature_prune_height.py --configfile=test/config.ini` *(fails: No such file or directory: '/workspace/bitcoin/bin/bitgoldd')*

------
https://chatgpt.com/codex/tasks/task_b_68c44baa48a4832abb6383a002d79be8