### PR TITLE
chore: update network magic bytes

### DIFF
--- a/contrib/linearize/example-linearize.cfg
+++ b/contrib/linearize/example-linearize.cfg
@@ -22,22 +22,22 @@ max_height=313000
 # bootstrap.dat input/output settings (linearize-data)
 
 # mainnet
-netmagic=f9beb4d9
+netmagic=fcc1c6dc
 genesis=000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f
 input=/home/example/.bitcoin/blocks
 
 # testnet
-#netmagic=0b110907
+#netmagic=b2d3f4a5
 #genesis=000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943
 #input=/home/example/.bitcoin/testnet3/blocks
 
 # regtest
-#netmagic=fabfb5da
+#netmagic=abbccdde
 #genesis=0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206
 #input=/home/example/.bitcoin/regtest/blocks
 
 # signet
-#netmagic=0a03cf40
+#netmagic=b3c4d5e6
 #genesis=00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6
 #input=/home/example/.bitcoin/signet/blocks
 

--- a/contrib/linearize/linearize-data.py
+++ b/contrib/linearize/linearize-data.py
@@ -287,7 +287,7 @@ if __name__ == '__main__':
     settings['rev_hash_bytes'] = settings['rev_hash_bytes'].lower()
 
     if 'netmagic' not in settings:
-        settings['netmagic'] = 'f9beb4d9'
+        settings['netmagic'] = 'fcc1c6dc'
     if 'genesis' not in settings:
         settings['genesis'] = '000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f'
     if 'input' not in settings:

--- a/doc/networking.md
+++ b/doc/networking.md
@@ -4,10 +4,10 @@ This document summarizes network parameters for the various BitGold networks.
 
 | Network  | Magic bytes | Default port | DNS seed nodes |
 |----------|-------------|--------------|----------------|
-| Mainnet  | `fbc0c5db`  | `8888`       | `seed.bitgold.org`, `seed.bitgold.net`, `seed.bitgold.co`, `seed.bitgold.io`, `seed.bitgold.info` |
-| Testnet  | `b1d2f3a4`  | `28889`      | `testnet-seed.bitgold.org`, `seed-testnet.bitgold.org` |
-| Signet   | `b2c3d4e5`  | `38888`      | *(none)* |
-| Regtest  | `aabbccdd`  | `38333`      | *(none)* |
+| Mainnet  | `fcc1c6dc`  | `8888`       | `seed.bitgold.org`, `seed.bitgold.net`, `seed.bitgold.co`, `seed.bitgold.io`, `seed.bitgold.info` |
+| Testnet  | `b2d3f4a5`  | `28889`      | `testnet-seed.bitgold.org`, `seed-testnet.bitgold.org` |
+| Signet   | `b3c4d5e6`  | `38888`      | *(none)* |
+| Regtest  | `abbccdde`  | `38333`      | *(none)* |
 
 Magic bytes appear in the P2P message header and help nodes identify the network
 of incoming connections. Default ports indicate where nodes listen for inbound

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -150,10 +150,10 @@ public:
          * The characters are rarely used upper ASCII, not valid as UTF-8, and produce
          * a large 32-bit integer with any alignment.
          */
-        pchMessageStart[0] = 0xfb;
-        pchMessageStart[1] = 0xc0;
-        pchMessageStart[2] = 0xc5;
-        pchMessageStart[3] = 0xdb;
+        pchMessageStart[0] = 0xfc;
+        pchMessageStart[1] = 0xc1;
+        pchMessageStart[2] = 0xc6;
+        pchMessageStart[3] = 0xdc;
         nDefaultPort = 8888;
         nPruneAfterHeight = 100'000;
         m_assumed_blockchain_size = 720; // MB
@@ -299,10 +299,10 @@ public:
         consensus.nMinimumChainWork = uint256{};
         consensus.defaultAssumeValid = uint256{};
 
-        pchMessageStart[0] = 0xb1;
-        pchMessageStart[1] = 0xd2;
-        pchMessageStart[2] = 0xf3;
-        pchMessageStart[3] = 0xa4;
+        pchMessageStart[0] = 0xb2;
+        pchMessageStart[1] = 0xd3;
+        pchMessageStart[2] = 0xf4;
+        pchMessageStart[3] = 0xa5;
         nDefaultPort = 28889;
         nPruneAfterHeight = 1000;
         m_assumed_blockchain_size = 200;
@@ -571,10 +571,10 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_BULLETPROOF].threshold = 1815;         // 90%
         consensus.vDeployments[Consensus::DEPLOYMENT_BULLETPROOF].period = 2016;
 
-        pchMessageStart[0] = 0xb2;
-        pchMessageStart[1] = 0xc3;
-        pchMessageStart[2] = 0xd4;
-        pchMessageStart[3] = 0xe5;
+        pchMessageStart[0] = 0xb3;
+        pchMessageStart[1] = 0xc4;
+        pchMessageStart[2] = 0xd5;
+        pchMessageStart[3] = 0xe6;
 
         nDefaultPort = 38888;
         nPruneAfterHeight = 1000;
@@ -676,10 +676,10 @@ public:
         consensus.nMinimumChainWork = uint256{};
         consensus.defaultAssumeValid = uint256{};
 
-        pchMessageStart[0] = 0xaa;
-        pchMessageStart[1] = 0xbb;
-        pchMessageStart[2] = 0xcc;
-        pchMessageStart[3] = 0xdd;
+        pchMessageStart[0] = 0xab;
+        pchMessageStart[1] = 0xbc;
+        pchMessageStart[2] = 0xcd;
+        pchMessageStart[3] = 0xde;
         nDefaultPort = 38333;
         nPruneAfterHeight = opts.fastprune ? 100 : 1000;
         m_assumed_blockchain_size = 0;

--- a/test/functional/feature_loadblock.py
+++ b/test/functional/feature_loadblock.py
@@ -52,7 +52,7 @@ class LoadblockTest(BitcoinTestFramework):
             cfg.write(f"host={node_url.hostname}\n")
             cfg.write(f"output_file={bootstrap_file}\n")
             cfg.write("max_height=100\n")
-            cfg.write("netmagic=fabfb5da\n")
+            cfg.write("netmagic=abbccdde\n")
             cfg.write(f"input={blocks_dir}\n")
             cfg.write(f"genesis={genesis_block}\n")
             cfg.write(f"hashlist={hash_list.name}\n")

--- a/test/functional/p2p_magic_bytes.py
+++ b/test/functional/p2p_magic_bytes.py
@@ -18,19 +18,20 @@ class P2PMagicBytesTest(BitcoinTestFramework):
             raise SkipTest("magic bytes are v1-specific")
 
         # Override mainnet magic bytes for the BitGold network
-        MAGIC_BYTES[""] = b"\xfb\xc0\xc5\xdb"
+        MAGIC_BYTES[""] = b"\xfc\xc1\xc6\xdc"
+        MAGIC_BYTES["old"] = b"\xfb\xc0\xc5\xdb"
 
         self.log.info("Connecting with correct magic to default port 8888")
         good_conn = self.nodes[0].add_p2p_connection(P2PInterface(), dstport=8888)
         good_conn.wait_for_verack()
         self.nodes[0].disconnect_p2ps()
 
-        self.log.info("Connecting with incorrect magic disconnects")
+        self.log.info("Connecting with old magic disconnects")
         bad_conn = P2PInterface()
         bad_conn.peer_connect(
             dstaddr="127.0.0.1",
             dstport=8888,
-            net="regtest",
+            net="old",
             timeout_factor=self.nodes[0].timeout_factor,
             supports_v2_p2p=False,
             send_version=True,

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -82,10 +82,10 @@ MAX_OP_RETURN_RELAY = 100_000
 DEFAULT_MEMPOOL_EXPIRY_HOURS = 336  # hours
 
 MAGIC_BYTES = {
-    "mainnet": b"\xf9\xbe\xb4\xd9",
-    "testnet4": b"\x1c\x16\x3f\x28",
-    "regtest": b"\xfa\xbf\xb5\xda",
-    "signet": b"\x0a\x03\xcf\x40",
+    "mainnet": b"\xfc\xc1\xc6\xdc",
+    "testnet4": b"\xb2\xd3\xf4\xa5",
+    "regtest": b"\xab\xbc\xcd\xde",
+    "signet": b"\xb3\xc4\xd5\xe6",
 }
 
 def sha256(s):


### PR DESCRIPTION
## Summary
- tweak BitGold network magic for main, test, signet, and regtest
- disconnect peers advertising old magic
- cover handshake magic checks with a regression test

## Testing
- `cmake -B build -GNinja` *(fails: libsecp256k1_zkp >= 0.6.1 not found)*
- `python3 test/functional/p2p_magic_bytes.py` *(fails: test/config.ini missing)*

------
https://chatgpt.com/codex/tasks/task_b_68c44ba72d48832aa2cf5b9b80264d49