### PR TITLE
chore: update DNS seed list and tests

### DIFF
--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -178,12 +178,12 @@ public:
                uint256{"0000072775275721f1a3aebb47f462aca90027230a88ceb29f4aad95446acd9d"});
         assert(genesis.hashMerkleRoot ==
                uint256{"66c3315af5839b587720eaac8e0966dd93a7211a39c633deba4c0625ac86623b"});
-        // Ensure DNS entries are coordinated externally before release.
-        vSeeds.emplace_back("seed.bitgold.org");
-        vSeeds.emplace_back("seed.bitgold.net");
-        vSeeds.emplace_back("seed.bitgold.co");
-        vSeeds.emplace_back("seed.bitgold.io");
-        vSeeds.emplace_back("seed.bitgold.info");
+        // Final BitGold mainnet DNS seeds. Keep this list in sync with deployed seeders.
+        vSeeds.emplace_back("dnsseed.bitgold.org");
+        vSeeds.emplace_back("dnsseed.bitgold.com");
+        vSeeds.emplace_back("dnsseed.bitgold.io");
+        vSeeds.emplace_back("dnsseed.bitgold.net");
+        vSeeds.emplace_back("dnsseed.bitgold.co");
 
         // Note that of those which support the service bits prefix, most only support a subset of
         // possible options.
@@ -316,9 +316,9 @@ public:
         assert(genesis.hashMerkleRoot == uint256{"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"});
         vFixedSeeds.clear();
         vSeeds.clear();
-        // BitGold-specific testnet seeds
+        // Final BitGold testnet DNS seeds. Keep this list in sync with deployed testnet seeders.
         vSeeds.emplace_back("testnet-seed.bitgold.org");
-        vSeeds.emplace_back("seed-testnet.bitgold.org");
+        vSeeds.emplace_back("testnet-seed.bitgold.net");
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1, 65);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1, 78);
@@ -437,9 +437,9 @@ public:
 
         vFixedSeeds.clear();
         vSeeds.clear();
-        // BitGold-specific testnet seeds
-        vSeeds.emplace_back("testnet-seed.bitgold.org");
-        vSeeds.emplace_back("seed-testnet.bitgold.org");
+        // Final BitGold testnet4 DNS seeds. Keep this list in sync with deployed seeders.
+        vSeeds.emplace_back("testnet4-seed.bitgold.org");
+        vSeeds.emplace_back("testnet4-seed.bitgold.net");
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1, 65);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1, 78);

--- a/test/functional/p2p_dns_seeds.py
+++ b/test/functional/p2p_dns_seeds.py
@@ -23,6 +23,7 @@ class P2PDNSSeeds(BitcoinTestFramework):
         self.existing_block_relay_connections_test()
         self.force_dns_test()
         self.wait_time_tests()
+        self.bootstrap_using_dns_seeds_test()
 
     def init_arg_tests(self):
         fakeaddr = "fakenodeaddr.fakedomain.invalid."
@@ -123,6 +124,21 @@ class P2PDNSSeeds(BitcoinTestFramework):
 
         # The delay should be 5 mins
         with self.nodes[0].assert_debug_log(expected_msgs=["Waiting 300 seconds before querying DNS seeds.\n"]):
+            self.restart_node(0)
+
+    def bootstrap_using_dns_seeds_test(self):
+        self.log.info("Check that the updated DNS seeds are queried for peer bootstrap")
+        seeds = [
+            "dnsseed.bitgold.org",
+            "dnsseed.bitgold.com",
+            "dnsseed.bitgold.io",
+            "dnsseed.bitgold.net",
+            "dnsseed.bitgold.co",
+        ]
+        with self.nodes[0].assert_debug_log(
+            expected_msgs=[f"Loading addresses from DNS seed {s}" for s in seeds],
+            timeout=12,
+        ):
             self.restart_node(0)
 
 


### PR DESCRIPTION
## Summary
- replace placeholder BitGold DNS seeds with final domains for mainnet and test networks
- note to keep seed lists aligned with deployed infrastructure
- cover updated seeds in `p2p_dns_seeds.py` bootstrap test

## Testing
- `python3 -m py_compile test/functional/p2p_dns_seeds.py`
- `cmake -S . -B build` *(fails: libsecp256k1_zkp >= 0.6.1 not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c44ba94d34832aaefcc399e1a02cb2