### PR TITLE
Clarify address prefixes and add negative tests

### DIFF
--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -191,7 +191,9 @@ public:
         // service bits we want, but we should get them updated to support all service bits wanted by any
         // release ASAP to avoid it where possible.
 
+        // Addresses using the public key prefix 25 begin with the Base58 character 'B'
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,25);
+        // Script addresses use prefix 40 which corresponds to Base58 'G'
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,40);
         base58Prefixes[SECRET_KEY] =     std::vector<unsigned char>(1,153);
 

--- a/test/functional/address_prefixes.py
+++ b/test/functional/address_prefixes.py
@@ -49,6 +49,11 @@ class AddressPrefixesTest(BitcoinTestFramework):
         assert legacy[0] == 'B'
         script = main.getnewaddress(address_type='p2sh-segwit')
         assert script[0] == 'G'
+        # Modified prefixes should be rejected
+        bad_legacy = 'G' + legacy[1:]
+        bad_script = 'B' + script[1:]
+        assert_equal(main.validateaddress(bad_legacy)["isvalid"], False)
+        assert_equal(main.validateaddress(bad_script)["isvalid"], False)
         bech32 = main.getnewaddress("", "bech32")
         assert bech32.startswith('bg1')
         wif = main.dumpprivkey(legacy)


### PR DESCRIPTION
## Summary
- Document Base58 mapping for mainnet public key and script address prefixes
- Expand address prefix functional test to check invalid prefixes

## Testing
- `test/functional/address_prefixes.py` *(fails: FileNotFoundError: '/workspace/bitcoin/test/config.ini')*

------
https://chatgpt.com/codex/tasks/task_b_68c44bad1f08832ab258d7e497d9681e