### PR TITLE
Clarify stake timestamp rules and add regression tests

### DIFF
--- a/doc/posv3.1.md
+++ b/doc/posv3.1.md
@@ -8,11 +8,13 @@ spacing.
 ## Consensus rules and activation
 
 - **Activation** – Nodes begin enforcing PoS v3.1 at the agreed block height
-  (set in `chainparams.cpp`). Prior releases continue to follow legacy rules
-  but fall out of consensus after activation.
-- **Timestamp granularity** – Block timestamps must be multiples of 16 seconds.
+   (set in `chainparams.cpp`). Prior releases continue to follow legacy rules
+   but fall out of consensus after activation.
+- **Timestamp rules** – Block timestamps must satisfy `(nTime & nStakeTimestampMask) == 0`,
+   enforcing 16‑second granularity, and be at least `nStakeTargetSpacing`
+   seconds after the previous block.
 - **Stake eligibility** – Inputs must contain at least 1&nbsp;BG and mature for one
-  hour before they can stake.
+   hour before they can stake.
 - **Block structure** – Each block contains a zero‑value coinbase followed by the
   coinstake transaction, which pays the input amount plus subsidy.
 - **Block signature** – The staking node signs the block header hash with the key

--- a/src/kernel/stake.h
+++ b/src/kernel/stake.h
@@ -38,13 +38,21 @@ bool ContextualCheckProofOfStake(const CBlock& block,
                                  const CChain& chain,
                                  const Consensus::Params& params);
 
+/** Result codes for stake timestamp validation. */
+enum class StakeTimeValidationResult {
+    OK = 0,
+    MASK,    //!< timestamp not aligned to nStakeTimestampMask
+    FUTURE,  //!< timestamp too far in the future
+    SPACING, //!< timestamp earlier than nStakeTargetSpacing after prev block
+};
+
 /** Basic timestamp checks for a staked block. */
-inline bool CheckStakeTimestamp(const CBlockHeader& h, unsigned int prev_time, const Consensus::Params& p)
+inline StakeTimeValidationResult CheckStakeTimestamp(const CBlockHeader& h, unsigned int prev_time, const Consensus::Params& p)
 {
-    if ((h.nTime & p.nStakeTimestampMask) != 0) return false;
-    if (h.nTime > GetTime() + 15) return false;
-    if (h.nTime < prev_time + p.nStakeTargetSpacing) return false;
-    return true;
+    if ((h.nTime & p.nStakeTimestampMask) != 0) return StakeTimeValidationResult::MASK;
+    if (h.nTime > GetTime() + 15) return StakeTimeValidationResult::FUTURE;
+    if (h.nTime < prev_time + p.nStakeTargetSpacing) return StakeTimeValidationResult::SPACING;
+    return StakeTimeValidationResult::OK;
 }
 
 } // namespace kernel

--- a/src/pos/stake.h
+++ b/src/pos/stake.h
@@ -50,12 +50,19 @@ bool IsProofOfStake(const CBlock& block);
 /** Verify the signature on a proof-of-stake block. */
 bool CheckBlockSignature(const CBlock& block);
 
-inline bool CheckStakeTimestamp(const CBlockHeader& h, unsigned int prev_time, const Consensus::Params& p)
+enum class StakeTimeValidationResult {
+    OK = 0,
+    MASK,
+    FUTURE,
+    SPACING,
+};
+
+inline StakeTimeValidationResult CheckStakeTimestamp(const CBlockHeader& h, unsigned int prev_time, const Consensus::Params& p)
 {
-    if ((h.nTime & p.nStakeTimestampMask) != 0) return false;
-    if (h.nTime > GetTime() + 15) return false;
-    if (h.nTime < prev_time + p.nStakeTargetSpacing) return false;
-    return true;
+    if ((h.nTime & p.nStakeTimestampMask) != 0) return StakeTimeValidationResult::MASK;
+    if (h.nTime > GetTime() + 15) return StakeTimeValidationResult::FUTURE;
+    if (h.nTime < prev_time + p.nStakeTargetSpacing) return StakeTimeValidationResult::SPACING;
+    return StakeTimeValidationResult::OK;
 }
 
 #endif // BITCOIN_POS_STAKE_H

--- a/src/test/pos_difficulty_tests.cpp
+++ b/src/test/pos_difficulty_tests.cpp
@@ -64,15 +64,15 @@ BOOST_AUTO_TEST_CASE(stake_timestamp_mask)
 
     // Valid timestamp: divisible by mask, after previous block, and not far in the future
     header.nTime = prev_time + params.nStakeTargetSpacing;
-    BOOST_CHECK(kernel::CheckStakeTimestamp(header, prev_time, params));
+    BOOST_CHECK(kernel::CheckStakeTimestamp(header, prev_time, params) == kernel::StakeTimeValidationResult::OK);
 
     // Fails mask divisibility
     header.nTime |= 1;
-    BOOST_CHECK(!kernel::CheckStakeTimestamp(header, prev_time, params));
+    BOOST_CHECK(kernel::CheckStakeTimestamp(header, prev_time, params) == kernel::StakeTimeValidationResult::MASK);
 
     // Valid mask but too far in the future
     header.nTime = (GetTime() + 16) & ~params.nStakeTimestampMask;
-    BOOST_CHECK(!kernel::CheckStakeTimestamp(header, prev_time, params));
+    BOOST_CHECK(kernel::CheckStakeTimestamp(header, prev_time, params) == kernel::StakeTimeValidationResult::FUTURE);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/functional/stake_timestamp.py
+++ b/test/functional/stake_timestamp.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Ensure blocks violating stake timestamp rules are rejected."""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.blocktools import create_block, create_coinbase
+from test_framework.messages import (
+    CTransaction,
+    CTxIn,
+    CTxOut,
+    COutPoint,
+    COIN,
+    hash256,
+    uint256_from_compact,
+)
+from test_framework.script import CScript
+from test_framework.util import assert_equal
+
+MIN_STAKE_AGE = 60 * 60
+
+
+def check_kernel(prev_hash, prev_height, prev_time, nbits, stake_hash, stake_time, amount, prevout, ntime, mask):
+    if ntime & mask:
+        return False
+    if ntime <= stake_time or ntime - stake_time < MIN_STAKE_AGE:
+        return False
+    stake_modifier = hash256(
+        bytes.fromhex(prev_hash)[::-1]
+        + prev_height.to_bytes(4, "little")
+        + prev_time.to_bytes(4, "little")
+    )
+    ntime_masked = ntime & ~mask
+    stake_time_masked = stake_time & ~mask
+    data = (
+        stake_modifier
+        + bytes.fromhex(stake_hash)[::-1]
+        + stake_time_masked.to_bytes(4, "little")
+        + bytes.fromhex(prevout["txid"])[::-1]
+        + prevout["vout"].to_bytes(4, "little")
+        + ntime_masked.to_bytes(4, "little")
+    )
+    proof = hash256(data)
+    target = uint256_from_compact(nbits) * (amount // COIN)
+    return int.from_bytes(proof[::-1], "big") <= target
+
+
+class StakeTimestampTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    def run_test(self):
+        node = self.nodes[0]
+        info = node.getblockchaininfo()
+        mask = info["pos_timestamp_mask"]
+        spacing = info["pos_target_spacing"]
+
+        addr = node.getnewaddress()
+        node.generatetoaddress(150, addr)
+
+        unspent = node.listunspent()[0]
+        txid = unspent["txid"]
+        vout = unspent["vout"]
+        amount = int(unspent["amount"] * COIN)
+        prevout = {"txid": txid, "vout": vout}
+
+        prev_height = node.getblockcount()
+        prev_hash = node.getbestblockhash()
+        prev_block = node.getblock(prev_hash)
+        nbits = int(prev_block["bits"], 16)
+        prev_time = prev_block["time"]
+
+        stake_block_hash = node.gettransaction(txid)["blockhash"]
+        stake_time = node.getblock(stake_block_hash)["time"]
+
+        ntime = (prev_time + spacing) & ~mask
+        while not check_kernel(
+            prev_hash,
+            prev_height,
+            prev_time,
+            nbits,
+            stake_block_hash,
+            stake_time,
+            amount,
+            prevout,
+            ntime,
+            mask,
+        ):
+            ntime += 16
+
+        script = CScript(bytes.fromhex(unspent["scriptPubKey"]))
+
+        def make_block(ntime):
+            coinstake = CTransaction()
+            coinstake.nLockTime = ntime
+            coinstake.vin.append(CTxIn(COutPoint(int(txid, 16), vout)))
+            coinstake.vout.append(CTxOut(0, CScript()))
+            reward = 50 * COIN
+            coinstake.vout.append(CTxOut(amount + reward, script))
+            signed = node.signrawtransactionwithwallet(coinstake.serialize().hex())["hex"]
+            coinstake = CTransaction()
+            coinstake.deserialize(bytes.fromhex(signed))
+            coinbase = create_coinbase(prev_height + 1, nValue=0)
+            block = create_block(
+                int(prev_hash, 16),
+                coinbase,
+                ntime,
+                tmpl={"bits": prev_block["bits"], "height": prev_height + 1},
+                txlist=[coinstake],
+            )
+            block.hashMerkleRoot = block.calc_merkle_root()
+            return block
+
+        # Block failing mask divisibility
+        bad_mask_block = make_block(ntime + 1)
+        assert_equal(node.submitblock(bad_mask_block.serialize().hex()), "bad-pos-time-mask")
+        assert_equal(node.getblockcount(), prev_height)
+
+        # Block failing minimum spacing
+        bad_spacing_time = (prev_time & ~mask) + 16
+        assert bad_spacing_time < prev_time + spacing
+        bad_spacing_block = make_block(bad_spacing_time)
+        assert_equal(node.submitblock(bad_spacing_block.serialize().hex()), "bad-pos-time-spacing")
+        assert_equal(node.getblockcount(), prev_height)
+
+        # Finally submit a valid block
+        good_block = make_block(ntime)
+        assert node.submitblock(good_block.serialize().hex()) is None
+        assert_equal(node.getblockcount(), prev_height + 1)
+
+
+if __name__ == "__main__":
+    StakeTimestampTest(__file__).main()


### PR DESCRIPTION
## Summary
- document stake timestamp mask and minimum spacing requirements
- provide explicit error codes for stake timestamp failures
- add regression test covering mask and spacing violations

## Testing
- `python3 test/functional/test_runner.py stake_timestamp.py` *(fails: FileNotFoundError: /workspace/bitcoin/test/functional/../config.ini)*
- `../configure ..` *(fails: libsecp256k1_zkp >= 0.6.1 not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c45ce80b4c832a8ad6541802b06dd2