### PR TITLE
Track and expose dividend history

### DIFF
--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -17,6 +17,7 @@
 #include <util/transaction_identifier.h>
 #include <util/ui_change_type.h>
 #include <wallet/types.h>
+#include <map>
 
 #include <cstdint>
 #include <functional>
@@ -162,6 +163,12 @@ public:
 
     //! Retrieve staking statistics.
     virtual wallet::StakingStats getStakingStats() = 0;
+    //! Retrieve dividend pool balance.
+    virtual CAmount getDividendBalance() = 0;
+    //! Estimate next dividend payout.
+    virtual std::pair<int, std::map<std::string, CAmount>> getNextDividend() = 0;
+    //! Retrieve dividend history for wallet addresses.
+    virtual std::map<int, std::map<std::string, CAmount>> getDividendHistory() = 0;
 
     //! Abandon transaction.
     virtual bool abandonTransaction(const Txid& txid) = 0;

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -167,6 +167,8 @@ if(ENABLE_WALLET)
       openuridialog.h
       overviewpage.cpp
       overviewpage.h
+      dividendpage.cpp
+      dividendpage.h
       paymentserver.cpp
       paymentserver.h
       psbtoperationsdialog.cpp

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -280,6 +280,13 @@ void BitcoinGUI::createActions()
     historyAction->setShortcut(QKeySequence(QStringLiteral("Alt+4")));
     tabGroup->addAction(historyAction);
 
+    dividendAction = new QAction(platformStyle->SingleColorIcon(":/icons/overview"), tr("&Dividends"), this);
+    dividendAction->setStatusTip(tr("Show dividend information"));
+    dividendAction->setToolTip(dividendAction->statusTip());
+    dividendAction->setCheckable(true);
+    dividendAction->setShortcut(QKeySequence(QStringLiteral("Alt+5")));
+    tabGroup->addAction(dividendAction);
+
 #ifdef ENABLE_WALLET
     // These showNormalIfMinimized are needed because Send Coins and Receive Coins
     // can be triggered from the tray menu, and need to show the GUI to be useful.
@@ -291,6 +298,8 @@ void BitcoinGUI::createActions()
     connect(receiveCoinsAction, &QAction::triggered, this, &BitcoinGUI::gotoReceiveCoinsPage);
     connect(historyAction, &QAction::triggered, [this]{ showNormalIfMinimized(); });
     connect(historyAction, &QAction::triggered, this, &BitcoinGUI::gotoHistoryPage);
+    connect(dividendAction, &QAction::triggered, [this]{ showNormalIfMinimized(); });
+    connect(dividendAction, &QAction::triggered, this, &BitcoinGUI::gotoDividendPage);
 #endif // ENABLE_WALLET
 
     quitAction = new QAction(tr("E&xit"), this);
@@ -604,6 +613,7 @@ void BitcoinGUI::createToolBars()
         toolbar->addAction(sendCoinsAction);
         toolbar->addAction(receiveCoinsAction);
         toolbar->addAction(historyAction);
+        toolbar->addAction(dividendAction);
         overviewAction->setChecked(true);
 
 #ifdef ENABLE_WALLET
@@ -996,6 +1006,12 @@ void BitcoinGUI::gotoSendCoinsPage(QString addr)
 {
     sendCoinsAction->setChecked(true);
     if (walletFrame) walletFrame->gotoSendCoinsPage(addr);
+}
+
+void BitcoinGUI::gotoDividendPage()
+{
+    dividendAction->setChecked(true);
+    if (walletFrame) walletFrame->gotoDividendPage();
 }
 
 void BitcoinGUI::gotoSignMessageTab(QString addr)

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -135,6 +135,7 @@ private:
     QToolBar* appToolBar = nullptr;
     QAction* overviewAction = nullptr;
     QAction* historyAction = nullptr;
+    QAction* dividendAction = nullptr;
     QAction* quitAction = nullptr;
     QAction* sendCoinsAction = nullptr;
     QAction* usedSendingAddressesAction = nullptr;
@@ -287,6 +288,8 @@ public Q_SLOTS:
     void gotoReceiveCoinsPage();
     /** Switch to send coins page */
     void gotoSendCoinsPage(QString addr = "");
+    /** Switch to dividend page */
+    void gotoDividendPage();
 
     /** Show Sign/Verify Message dialog and switch to sign message tab */
     void gotoSignMessageTab(QString addr = "");

--- a/src/qt/dividendpage.cpp
+++ b/src/qt/dividendpage.cpp
@@ -1,0 +1,40 @@
+#include <qt/dividendpage.h>
+
+#include <qt/bitcoinunits.h>
+#include <qt/walletmodel.h>
+#include <qt/clientmodel.h>
+#include <qt/optionsmodel.h>
+#include <interfaces/node.h>
+#include <wallet/wallet.h>
+
+#include <QVBoxLayout>
+#include <QLabel>
+
+DividendPage::DividendPage(const PlatformStyle* platformStyle, QWidget* parent)
+    : QWidget(parent), m_platform_style(platformStyle)
+{
+    QVBoxLayout* vbox = new QVBoxLayout(this);
+    poolLabel = new QLabel(tr("Pool: 0"), this);
+    nextLabel = new QLabel(tr("Next height: n/a"), this);
+    vbox->addWidget(poolLabel);
+    vbox->addWidget(nextLabel);
+}
+
+void DividendPage::setClientModel(ClientModel* model)
+{
+    clientModel = model;
+}
+
+void DividendPage::setWalletModel(WalletModel* model)
+{
+    walletModel = model;
+}
+
+void DividendPage::updateData()
+{
+    if (!walletModel) return;
+    CAmount pool = walletModel->wallet().getDividendBalance();
+    poolLabel->setText(tr("Pool: %1").arg(BitcoinUnits::format(walletModel->getOptionsModel()->getDisplayUnit(), pool)));
+    auto next = walletModel->wallet().getNextDividend();
+    nextLabel->setText(tr("Next height: %1").arg(next.first));
+}

--- a/src/qt/dividendpage.h
+++ b/src/qt/dividendpage.h
@@ -1,0 +1,30 @@
+#ifndef BITCOIN_QT_DIVIDENDPAGE_H
+#define BITCOIN_QT_DIVIDENDPAGE_H
+
+#include <QWidget>
+
+class ClientModel;
+class WalletModel;
+class QLabel;
+class PlatformStyle;
+
+class DividendPage : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit DividendPage(const PlatformStyle* platformStyle, QWidget* parent = nullptr);
+    void setClientModel(ClientModel* model);
+    void setWalletModel(WalletModel* model);
+
+public Q_SLOTS:
+    void updateData();
+
+private:
+    ClientModel* clientModel{nullptr};
+    WalletModel* walletModel{nullptr};
+    QLabel* poolLabel;
+    QLabel* nextLabel;
+    const PlatformStyle* m_platform_style;
+};
+
+#endif // BITCOIN_QT_DIVIDENDPAGE_H

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -176,6 +176,13 @@ void WalletFrame::gotoSendCoinsPage(QString addr)
         i.value()->gotoSendCoinsPage(addr);
 }
 
+void WalletFrame::gotoDividendPage()
+{
+    QMap<WalletModel*, WalletView*>::const_iterator i;
+    for (i = mapWalletViews.constBegin(); i != mapWalletViews.constEnd(); ++i)
+        i.value()->gotoDividendPage();
+}
+
 void WalletFrame::gotoSignMessageTab(QString addr)
 {
     WalletView *walletView = currentWalletView();

--- a/src/qt/walletframe.h
+++ b/src/qt/walletframe.h
@@ -75,6 +75,7 @@ public Q_SLOTS:
     void gotoReceiveCoinsPage();
     /** Switch to send coins page */
     void gotoSendCoinsPage(QString addr = "");
+    void gotoDividendPage();
 
     /** Show Sign/Verify Message dialog and switch to sign message tab */
     void gotoSignMessageTab(QString addr = "");

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -17,6 +17,7 @@
 #include <qt/transactiontablemodel.h>
 #include <qt/transactionview.h>
 #include <qt/walletmodel.h>
+#include <qt/dividendpage.h>
 
 #include <interfaces/node.h>
 #include <node/interface_ui.h>
@@ -63,6 +64,9 @@ WalletView::WalletView(WalletModel* wallet_model, const PlatformStyle* _platform
     sendCoinsPage = new SendCoinsDialog(platformStyle);
     sendCoinsPage->setModel(walletModel);
 
+    dividendPage = new DividendPage(platformStyle);
+    dividendPage->setWalletModel(walletModel);
+
     usedSendingAddressesPage = new AddressBookPage(platformStyle, AddressBookPage::ForEditing, AddressBookPage::SendingTab, this);
     usedSendingAddressesPage->setModel(walletModel->getAddressTableModel());
 
@@ -73,6 +77,7 @@ WalletView::WalletView(WalletModel* wallet_model, const PlatformStyle* _platform
     addWidget(transactionsPage);
     addWidget(receiveCoinsPage);
     addWidget(sendCoinsPage);
+    addWidget(dividendPage);
 
     connect(overviewPage, &OverviewPage::transactionClicked, this, &WalletView::transactionClicked);
     // Clicking on a transaction on the overview pre-selects the transaction on the transaction history page
@@ -120,6 +125,7 @@ void WalletView::setClientModel(ClientModel *_clientModel)
     overviewPage->setClientModel(_clientModel);
     sendCoinsPage->setClientModel(_clientModel);
     walletModel->setClientModel(_clientModel);
+    dividendPage->setClientModel(_clientModel);
 }
 
 void WalletView::processNewTransaction(const QModelIndex& parent, int start, int /*end*/)
@@ -164,6 +170,12 @@ void WalletView::gotoSendCoinsPage(QString addr)
 
     if (!addr.isEmpty())
         sendCoinsPage->setAddress(addr);
+}
+
+void WalletView::gotoDividendPage()
+{
+    setCurrentWidget(dividendPage);
+    dividendPage->updateData();
 }
 
 void WalletView::gotoSignMessageTab(QString addr)

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -19,6 +19,7 @@ class SendCoinsRecipient;
 class TransactionView;
 class WalletModel;
 class AddressBookPage;
+class DividendPage;
 
 QT_BEGIN_NAMESPACE
 class QModelIndex;
@@ -62,6 +63,7 @@ private:
     QWidget *transactionsPage;
     ReceiveCoinsDialog *receiveCoinsPage;
     SendCoinsDialog *sendCoinsPage;
+    DividendPage *dividendPage;
     AddressBookPage *usedSendingAddressesPage;
     AddressBookPage *usedReceivingAddressesPage;
 
@@ -79,6 +81,7 @@ public Q_SLOTS:
     void gotoReceiveCoinsPage();
     /** Switch to send coins page */
     void gotoSendCoinsPage(QString addr = "");
+    void gotoDividendPage();
 
     /** Show Sign/Verify Message dialog and switch to sign message tab */
     void gotoSignMessageTab(QString addr = "");

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -27,6 +27,7 @@ static constexpr uint8_t DB_DIVIDEND_POOL{'D'};
 static constexpr uint8_t DB_STAKE_INFO{'I'};
 static constexpr uint8_t DB_PENDING_DIVIDENDS{'P'};
 static constexpr uint8_t DB_STAKE_SNAPSHOTS{'S'};
+static constexpr uint8_t DB_DIVIDEND_HISTORY{'Y'};
 // Keys used in previous version that might still be found in the DB:
 static constexpr uint8_t DB_COINS{'c'};
 
@@ -141,6 +142,18 @@ std::map<int, std::map<std::string, CAmount>> CCoinsViewDB::GetStakeSnapshots() 
 bool CCoinsViewDB::WriteStakeSnapshots(const std::map<int, std::map<std::string, CAmount>>& snaps)
 {
     return m_db->Write(DB_STAKE_SNAPSHOTS, snaps);
+}
+
+std::map<int, dividend::Payouts> CCoinsViewDB::GetDividendHistory() const
+{
+    std::map<int, dividend::Payouts> hist;
+    m_db->Read(DB_DIVIDEND_HISTORY, hist);
+    return hist;
+}
+
+bool CCoinsViewDB::WriteDividendHistory(const std::map<int, dividend::Payouts>& hist)
+{
+    return m_db->Write(DB_DIVIDEND_HISTORY, hist);
 }
 
 bool CCoinsViewDB::BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &hashBlock) {

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -73,6 +73,8 @@ public:
     bool WritePendingDividends(const std::map<std::string, CAmount>& divs);
     std::map<int, std::map<std::string, CAmount>> GetStakeSnapshots() const;
     bool WriteStakeSnapshots(const std::map<int, std::map<std::string, CAmount>>& snaps);
+    std::map<int, dividend::Payouts> GetDividendHistory() const;
+    bool WriteDividendHistory(const std::map<int, dividend::Payouts>& hist);
 };
 
 #endif // BITCOIN_TXDB_H

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2421,6 +2421,7 @@ void Chainstate::LoadDividendPool()
     m_stake_info = CoinsDB().GetStakeInfo();
     m_pending_dividends = CoinsDB().GetPendingDividends();
     m_stake_snapshots = CoinsDB().GetStakeSnapshots();
+    m_dividend_history = CoinsDB().GetDividendHistory();
 }
 
 void Chainstate::AddToDividendPool(CAmount amount, int height)
@@ -2436,6 +2437,7 @@ void Chainstate::AddToDividendPool(CAmount amount, int height)
         for (const auto& [addr, amt] : payouts) {
             m_pending_dividends[addr] += amt;
         }
+        m_dividend_history.emplace(height, payouts);
         for (auto& [addr, info] : m_stake_info) {
             info.last_payout_height = height;
         }
@@ -2450,6 +2452,7 @@ void Chainstate::AddToDividendPool(CAmount amount, int height)
     CoinsDB().WriteStakeInfo(m_stake_info);
     CoinsDB().WritePendingDividends(m_pending_dividends);
     CoinsDB().WriteStakeSnapshots(m_stake_snapshots);
+    CoinsDB().WriteDividendHistory(m_dividend_history);
 }
 
 void Chainstate::UpdateStakeWeight(const std::string& addr, CAmount weight)

--- a/src/validation.h
+++ b/src/validation.h
@@ -638,6 +638,8 @@ public:
     std::map<std::string, CAmount> m_pending_dividends GUARDED_BY(::cs_main);
     //! Historical snapshots of stakes taken each quarter.
     std::map<int, std::map<std::string, CAmount>> m_stake_snapshots GUARDED_BY(::cs_main);
+    //! Historical dividend payouts keyed by height.
+    std::map<int, dividend::Payouts> m_dividend_history GUARDED_BY(::cs_main);
 
     /**
      * The base of the snapshot this chainstate was created from.
@@ -676,6 +678,7 @@ public:
     const std::map<std::string, StakeInfo>& GetStakeInfo() const EXCLUSIVE_LOCKS_REQUIRED(::cs_main) { return m_stake_info; }
     const std::map<std::string, CAmount>& GetPendingDividends() const EXCLUSIVE_LOCKS_REQUIRED(::cs_main) { return m_pending_dividends; }
     const std::map<int, std::map<std::string, CAmount>>& GetStakeSnapshots() const EXCLUSIVE_LOCKS_REQUIRED(::cs_main) { return m_stake_snapshots; }
+    const std::map<int, dividend::Payouts>& GetDividendHistory() const EXCLUSIVE_LOCKS_REQUIRED(::cs_main) { return m_dividend_history; }
     void UpdateStakeWeight(const std::string& addr, CAmount weight) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     CAmount ClaimDividend(const std::string& addr) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -1139,6 +1139,8 @@ RPCHelpMan abortrescan();
 // dividend
 RPCHelpMan getwalletdividends();
 RPCHelpMan claimwalletdividends();
+RPCHelpMan getwalletdividendhistory();
+RPCHelpMan getwalletnextdividend();
 
 std::span<const CRPCCommand> GetWalletRPCCommands()
 {
@@ -1213,6 +1215,8 @@ std::span<const CRPCCommand> GetWalletRPCCommands()
         {"wallet", &getstakestat},
         {"wallet", &getwalletdividends},
         {"wallet", &claimwalletdividends},
+        {"wallet", &getwalletdividendhistory},
+        {"wallet", &getwalletnextdividend},
     };
     return commands;
 }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -38,6 +38,7 @@
 #include <wallet/walletutil.h>
 #include <wallet/blinding.h>
 
+class Chainstate;
 #ifdef ENABLE_BULLETPROOFS
 #include <bulletproofs.h>
 #endif
@@ -521,6 +522,12 @@ public:
 
     /** Return current dividend pool balance. */
     CAmount GetDividendBalance() const;
+    /** Update indexed dividend history from chainstate. */
+    void UpdateDividendHistory(const Chainstate& chainstate) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    /** Return indexed dividend history. */
+    std::map<int, std::map<std::string, CAmount>> GetDividendHistory() const;
+    /** Return estimated next dividend payouts for wallet addresses. */
+    std::pair<int, std::map<std::string, CAmount>> GetNextDividend() const;
 
     /** Set the balance to keep reserved from staking. */
     void SetReserveBalance(CAmount amount);
@@ -557,6 +564,8 @@ public:
      * that hasn't confirmed yet. We wouldn't consider the Coin spent already,
      * but also shouldn't try to use it again. */
     std::set<COutPoint> setLockedCoins GUARDED_BY(cs_wallet);
+    //! Dividend history filtered for wallet addresses.
+    std::map<int, std::map<std::string, CAmount>> m_dividend_history GUARDED_BY(cs_wallet);
 
     /** Registered interfaces::Chain::Notifications handler. */
     std::unique_ptr<interfaces::Handler> m_chain_notifications_handler;

--- a/test/functional/dividend_history.py
+++ b/test/functional/dividend_history.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Test dividend history and next dividend RPCs."""
+from decimal import Decimal
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+QUARTER_BLOCKS = 16200
+
+class DividendHistoryTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        self.extra_args = [["-dividendpayouts=1"]]
+
+    def run_test(self):
+        node = self.nodes[0]
+        addr = node.getnewaddress()
+        node.generatetoaddress(1, addr)
+        assert_equal(node.getdividendhistory(), {})
+        nxt = node.getnextdividend()
+        assert "height" in nxt
+        remaining = QUARTER_BLOCKS - node.getblockcount()
+        node.generatetoaddress(remaining, addr)
+        hist = node.getdividendhistory()
+        assert str(QUARTER_BLOCKS) in hist
+        whist = node.getwalletdividendhistory()
+        assert str(QUARTER_BLOCKS) in whist
+        nxt2 = node.getnextdividend()
+        assert nxt2["height"] > QUARTER_BLOCKS
+        wnxt = node.getwalletnextdividend()
+        assert "height" in wnxt
+
+if __name__ == '__main__':
+    DividendHistoryTest().main()


### PR DESCRIPTION
## Summary
- persist dividend payout history in chainstate
- add RPCs for dividend history and next payout with wallet and GUI support
- cover dividend RPCs with functional test

## Testing
- `cmake -GNinja -B build` *(fails: libsecp256k1_zkp >= 0.6.1 not found)*
- `test/functional/test_runner.py dividend_history.py` *(fails: config.ini missing)*

------
https://chatgpt.com/codex/tasks/task_b_68c45ce41d88832abdf2e06f0b2f8b1a