### PR TITLE
refactor: add CheckCoinstakeRewards helper

### DIFF
--- a/test/functional/dividend_validation.py
+++ b/test/functional/dividend_validation.py
@@ -117,6 +117,72 @@ class DividendValidationTest(BitcoinTestFramework):
         validator_reward = reward * 9 // 10
         dividend_reward = reward - validator_reward
 
+        # Block missing dividend output
+        bad_coinstake = CTransaction()
+        bad_coinstake.nLockTime = ntime
+        bad_coinstake.vin.append(CTxIn(COutPoint(int(txid, 16), vout)))
+        bad_coinstake.vout.append(CTxOut(0, CScript()))
+        bad_coinstake.vout.append(CTxOut(amount + validator_reward, script))
+        signed_hex = node.signrawtransactionwithwallet(bad_coinstake.serialize().hex())["hex"]
+        bad_coinstake = CTransaction()
+        bad_coinstake.deserialize(bytes.fromhex(signed_hex))
+
+        bad_coinbase = create_coinbase(prev_height + 1, nValue=0)
+        bad_block = create_block(
+            int(prev_hash, 16),
+            bad_coinbase,
+            ntime,
+            tmpl={"bits": prev_block["bits"], "height": prev_height + 1},
+            txlist=[bad_coinstake],
+        )
+        bad_block.hashMerkleRoot = bad_block.calc_merkle_root()
+        node.p2p.send_blocks_and_test([bad_block], node, success=False, reject_reason=b"bad-dividend-missing")
+
+        # Block with incorrect dividend amount
+        bad_coinstake = CTransaction()
+        bad_coinstake.nLockTime = ntime
+        bad_coinstake.vin.append(CTxIn(COutPoint(int(txid, 16), vout)))
+        bad_coinstake.vout.append(CTxOut(0, CScript()))
+        bad_coinstake.vout.append(CTxOut(amount + validator_reward, script))
+        bad_coinstake.vout.append(CTxOut(dividend_reward - 1, CScript([OP_TRUE])))
+        signed_hex = node.signrawtransactionwithwallet(bad_coinstake.serialize().hex())["hex"]
+        bad_coinstake = CTransaction()
+        bad_coinstake.deserialize(bytes.fromhex(signed_hex))
+
+        bad_coinbase = create_coinbase(prev_height + 1, nValue=0)
+        bad_block = create_block(
+            int(prev_hash, 16),
+            bad_coinbase,
+            ntime,
+            tmpl={"bits": prev_block["bits"], "height": prev_height + 1},
+            txlist=[bad_coinstake],
+        )
+        bad_block.hashMerkleRoot = bad_block.calc_merkle_root()
+        node.p2p.send_blocks_and_test([bad_block], node, success=False, reject_reason=b"bad-dividend-amount")
+
+        # Block with extra outputs
+        bad_coinstake = CTransaction()
+        bad_coinstake.nLockTime = ntime
+        bad_coinstake.vin.append(CTxIn(COutPoint(int(txid, 16), vout)))
+        bad_coinstake.vout.append(CTxOut(0, CScript()))
+        bad_coinstake.vout.append(CTxOut(amount + validator_reward, script))
+        bad_coinstake.vout.append(CTxOut(dividend_reward, CScript([OP_TRUE])))
+        bad_coinstake.vout.append(CTxOut(0, CScript()))
+        signed_hex = node.signrawtransactionwithwallet(bad_coinstake.serialize().hex())["hex"]
+        bad_coinstake = CTransaction()
+        bad_coinstake.deserialize(bytes.fromhex(signed_hex))
+
+        bad_coinbase = create_coinbase(prev_height + 1, nValue=0)
+        bad_block = create_block(
+            int(prev_hash, 16),
+            bad_coinbase,
+            ntime,
+            tmpl={"bits": prev_block["bits"], "height": prev_height + 1},
+            txlist=[bad_coinstake],
+        )
+        bad_block.hashMerkleRoot = bad_block.calc_merkle_root()
+        node.p2p.send_blocks_and_test([bad_block], node, success=False, reject_reason=b"bad-dividend-extra")
+
         # Block with incorrect validator reward
         bad_coinstake = CTransaction()
         bad_coinstake.nLockTime = ntime


### PR DESCRIPTION
## Summary
- factor dividend payout checks into new `CheckCoinstakeRewards`
- ensure CheckBlock uses the helper
- add functional tests for missing, incorrect, and extra dividend outputs

## Testing
- `python3 test/functional/dividend_validation.py` *(fails: Binary not found: ./bin/bitgoldd)*

------
https://chatgpt.com/codex/tasks/task_b_68c45cdcdd4c832aa968a1606ac618b8