### PR TITLE
test: cover dividend claiming

### DIFF
--- a/doc/rpc/staking.md
+++ b/doc/rpc/staking.md
@@ -7,7 +7,7 @@ This document shows how to use RPC calls related to staking and dividends.
 Returns whether staking is enabled and if the wallet is currently staking.
 
 ```
-$ bitcoin-cli getstakinginfo
+$ bitgold-cli getstakinginfo
 {
   "enabled": true,
   "staking": false
@@ -20,7 +20,7 @@ Reserves a portion of the wallet balance from staking. Call with no
 parameters to return the current amount.
 
 ```
-$ bitcoin-cli setreservebalance true 100
+$ bitgold-cli setreservebalance true 100
 {
   "reserved": 100.00000000
 }
@@ -31,7 +31,7 @@ $ bitcoin-cli setreservebalance true 100
 Deprecated alias for `setreservebalance`.
 
 ```
-$ bitcoin-cli reservebalance
+$ bitgold-cli reservebalance
 {
   "reserved": 100.00000000
 }
@@ -43,9 +43,20 @@ Sets the minimum amount before a staking output is split. Setting the value
 to `0` disables splitting.
 
 ```
-$ bitcoin-cli setstakesplitthreshold 50
+$ bitgold-cli setstakesplitthreshold 50
 {
   "threshold": 50.00000000
+}
+```
+
+## `getdividendpool`
+
+Returns the current dividend pool amount.
+
+```
+$ bitgold-cli getdividendpool
+{
+  "amount": "12.50000000"
 }
 ```
 
@@ -54,7 +65,7 @@ $ bitcoin-cli setstakesplitthreshold 50
 Displays the dividend pool, stake information, and snapshots.
 
 ```
-$ bitcoin-cli getdividendinfo
+$ bitgold-cli getdividendinfo
 {
   "pool": "12.50000000",
   "stakes": {
@@ -78,7 +89,7 @@ Claims matured dividends for an address. Dividend payouts must be enabled
 with `-dividendpayouts`.
 
 ```
-$ bitcoin-cli claimdividends "addr"
+$ bitgold-cli claimdividends "addr"
 {
   "claimed": "0.25000000",
   "remaining": "12.25000000"

--- a/doc/wallet-guide.md
+++ b/doc/wallet-guide.md
@@ -19,9 +19,12 @@ Unlock the wallet for staking only using `walletpassphrase <pass> 0 true`. The w
 
 ## Dividend Claims
 
-Dividends mature into claimable outputs. Use `claimdividends` (GUI: **Claim** button) to sweep matured dividends into your balance.
+Check pending dividends with `bitgold-cli getwalletdividends`.
+Use `bitgold-cli claimwalletdividends` (GUI: **Claim** button) to sweep
+matured dividends into your balance.
 
-Dividend payouts are disabled by default. Enable them by launching the node with `-dividendpayouts`. When disabled, the `claimdividends` RPC will return an error.
+Dividend payouts are disabled by default. Enable them by launching the node
+with `-dividendpayouts`. When disabled, the claim RPCs will return an error.
 
 ## Security Best Practices
 

--- a/test/functional/rpc_staking_dividend.py
+++ b/test/functional/rpc_staking_dividend.py
@@ -4,11 +4,13 @@ from decimal import Decimal
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, assert_raises_rpc_error
 
+QUARTER_BLOCKS = 16200
+
 class StakingDividendRPCTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         self.setup_clean_chain = True
-        self.extra_args = [["-dividendpayouts=0"]]
+        self.extra_args = [["-dividendpayouts=1"]]
 
     def run_test(self):
         node = self.nodes[0]
@@ -28,7 +30,9 @@ class StakingDividendRPCTest(BitcoinTestFramework):
         pool = node.getdividendpool()
         assert "amount" in pool
         assert_equal(pool["amount"], Decimal("0"))
-        assert_raises_rpc_error(-1, "dividend payouts are disabled", node.claimdividends, "addr")
+        addr = node.getnewaddress()
+        result = node.claimdividends(addr)
+        assert_equal(result["claimed"], Decimal("0"))
 
         # dividend schedule
         stakes = [
@@ -38,6 +42,20 @@ class StakingDividendRPCTest(BitcoinTestFramework):
         schedule = node.getdividendschedule(stakes, 10, Decimal("30"))
         assert "A" in schedule and "B" in schedule
         assert_raises_rpc_error(-8, "stakes, height, pool required", node.getdividendschedule)
+
+        # Stake a block and advance to payout height
+        node.generatetoaddress(110, addr)
+        node.startstaking()
+        node.sendtoaddress(addr, 1)
+        start_height = node.getblockcount()
+        node.waitforblockheight(start_height + 1)
+        remaining = QUARTER_BLOCKS - node.getblockcount()
+        node.generatetoaddress(remaining, addr)
+
+        claim = node.claimdividends(addr)
+        assert claim["claimed"] > 0
+        repeat = node.claimdividends(addr)
+        assert_equal(repeat["claimed"], Decimal("0"))
 
 if __name__ == '__main__':
     StakingDividendRPCTest().main()


### PR DESCRIPTION
## Summary
- add dividend claim scenarios to wallet and RPC functional tests
- document staking and wallet dividend RPCs using bitgold-cli

## Testing
- `cmake --build build -j$(nproc)` *(fails: no matching function for call to ‘PeerManager::make’)*
- `./test/functional/test_runner.py wallet_dividend.py` *(fails: No such file or directory: '.../config.ini')*
- `./test/functional/test_runner.py` *(fails: No such file or directory: '.../config.ini')*

------
https://chatgpt.com/codex/tasks/task_b_68c45c512f48832aa1b1cad6c798e3cd