### PR TITLE
Rename Bitcoin manpages to Bitgold equivalents

### DIFF
--- a/contrib/devtools/gen-manpages.py
+++ b/contrib/devtools/gen-manpages.py
@@ -9,12 +9,12 @@ import tempfile
 import argparse
 
 BINARIES = [
-'bin/bitgoldd',
-'bin/bitgold-cli',
-'bin/bitcoin-tx',
-'bin/bitcoin-wallet',
-'bin/bitcoin-util',
-'bin/bitcoin-qt',
+    'bin/bitgoldd',
+    'bin/bitgold-cli',
+    'bin/bitgold-tx',
+    'bin/bitgold-wallet',
+    'bin/bitgold-util',
+    'bin/bitgold-qt',
 ]
 
 parser = argparse.ArgumentParser(

--- a/doc/man/bitgold-qt.1
+++ b/doc/man/bitgold-qt.1
@@ -1,5 +1,5 @@
-.TH BITCOIN-UTIL "1"
+.TH BITGOLD-QT "1"
 .SH NAME
-bitcoin-util \- manual page for bitcoin-util
+bitgold-qt \- manual page for bitgold-qt
 
 This is a placeholder file. Please follow the instructions in \fIcontrib/devtools/README.md\fR to generate the manual pages after a release.

--- a/doc/man/bitgold-tx.1
+++ b/doc/man/bitgold-tx.1
@@ -1,5 +1,5 @@
-.TH BITCOIN-WALLET "1"
+.TH BITGOLD-TX "1"
 .SH NAME
-bitcoin-wallet \- manual page for bitcoin-wallet
+bitgold-tx \- manual page for bitgold-tx
 
 This is a placeholder file. Please follow the instructions in \fIcontrib/devtools/README.md\fR to generate the manual pages after a release.

--- a/doc/man/bitgold-util.1
+++ b/doc/man/bitgold-util.1
@@ -1,5 +1,5 @@
-.TH BITCOIN-TX "1"
+.TH BITGOLD-UTIL "1"
 .SH NAME
-bitcoin-tx \- manual page for bitcoin-tx
+bitgold-util \- manual page for bitgold-util
 
 This is a placeholder file. Please follow the instructions in \fIcontrib/devtools/README.md\fR to generate the manual pages after a release.

--- a/doc/man/bitgold-wallet.1
+++ b/doc/man/bitgold-wallet.1
@@ -1,5 +1,5 @@
-.TH BITCOIN-QT "1"
+.TH BITGOLD-WALLET "1"
 .SH NAME
-bitcoin-qt \- manual page for bitcoin-qt
+bitgold-wallet \- manual page for bitgold-wallet
 
 This is a placeholder file. Please follow the instructions in \fIcontrib/devtools/README.md\fR to generate the manual pages after a release.


### PR DESCRIPTION
## Summary
- rename Bitcoin manual page placeholders to Bitgold equivalents
- update manpage generation script for new Bitgold binaries

## Testing
- `python3 contrib/devtools/gen-manpages.py --skip-missing-binaries` *(fails: no binaries found in /workspace/bitcoin/build)*

------
https://chatgpt.com/codex/tasks/task_b_68c45b6c5a58832ab74c6a1ee13d0b4d