### PR TITLE
docs: update Windows README for BitGold

### DIFF
--- a/doc/README_windows.txt
+++ b/doc/README_windows.txt
@@ -1,23 +1,23 @@
-Bitcoin Core
-=============
+BitGold Core
+============
 
 Intro
 -----
-Bitcoin is a free open source peer-to-peer electronic cash system that is
+BitGold is a free open source peer-to-peer electronic cash system that is
 completely decentralized, without the need for a central server or trusted
-parties.  Users hold the crypto keys to their own money and transact directly
+parties. Users hold the crypto keys to their own money and transact directly
 with each other, with the help of a P2P network to check for double-spending.
 
 
 Setup
 -----
-Unpack the files into a directory and run bitcoin-qt.exe.
+Unpack the files into a directory and run bitgold-qt.exe.
 
-Bitcoin Core is the original Bitcoin client and it builds the backbone of the network.
-However, it downloads and stores the entire history of Bitcoin transactions;
+BitGold Core is the original BitGold client and it builds the backbone of the network.
+However, it downloads and stores the entire history of BitGold transactions;
 depending on the speed of your computer and network connection, the synchronization
 process can take anywhere from a few hours to a day or more.
 
-See the bitcoin wiki at:
-  https://en.bitcoin.it/wiki/Main_Page
+See the BitGold documentation at:
+  https://docs.bitgold.org/
 for more help and information.


### PR DESCRIPTION
## Summary
- update Windows setup instructions to reference BitGold Core
- rename Qt executable to `bitgold-qt.exe`
- replace Bitcoin wiki link with BitGold docs

## Testing
- `test/lint/check-doc.py` (fails: `-stakesplitthreshold` undocumented)
- `test/lint/lint-spelling.py`

------
https://chatgpt.com/codex/tasks/task_b_68c45b6358b0832aa5bb33307135b8af