### PR TITLE
doc: sync mainnet DNS seeds with chainparams

### DIFF
--- a/doc/networking.md
+++ b/doc/networking.md
@@ -4,7 +4,7 @@ This document summarizes network parameters for the various BitGold networks.
 
 | Network  | Magic bytes | Default port | DNS seed nodes |
 |----------|-------------|--------------|----------------|
-| Mainnet  | `fcc1c6dc`  | `8888`       | `seed.bitgold.org`, `seed.bitgold.net`, `seed.bitgold.co`, `seed.bitgold.io`, `seed.bitgold.info` |
+| Mainnet  | `fcc1c6dc`  | `8888`       | `dnsseed.bitgold.org`, `dnsseed.bitgold.com`, `dnsseed.bitgold.io`, `dnsseed.bitgold.net`, `dnsseed.bitgold.co` |
 | Testnet  | `b2d3f4a5`  | `28889`      | `testnet-seed.bitgold.org`, `seed-testnet.bitgold.org` |
 | Signet   | `b3c4d5e6`  | `38888`      | *(none)* |
 | Regtest  | `abbccdde`  | `38333`      | *(none)* |


### PR DESCRIPTION
## Summary
- update networking guide to list same DNS seed domains as chainparams

## Testing
- `cmake -B build` *(fails: Could not find package configuration file provided by "Boost"*)
- `cmake --build build --target docs` *(fails: No rule to make target 'Makefile')*


------
https://chatgpt.com/codex/tasks/task_b_68c45ae63548832a85dee9812daf72d6