### PR TITLE
wallet: store multiple tx variants

### DIFF
--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -33,6 +33,8 @@
 
 #include <boost/test/unit_test.hpp>
 #include <univalue.h>
+#include <streams.h>
+#include <clientversion.h>
 
 using node::MAX_BLOCKFILE_SIZE;
 
@@ -700,6 +702,34 @@ BOOST_FIXTURE_TEST_CASE(CreateWalletWithoutChain, BasicTestingSetup)
     auto wallet = TestLoadWallet(context);
     BOOST_CHECK(wallet);
     WaitForDeleteWallet(std::move(wallet));
+}
+
+BOOST_FIXTURE_TEST_CASE(TxVariantsPersist, TestingSetup)
+{
+    CWallet wallet(m_node.chain.get(), "", CreateMockableWalletDatabase());
+    {
+        LOCK(wallet.cs_wallet);
+        CMutableTransaction mtx;
+        mtx.vin.resize(1);
+        mtx.vout.emplace_back(1, CScript());
+        CTransactionRef no_wit = MakeTransactionRef(mtx);
+        wallet.AddToWallet(no_wit, TxStateInactive{});
+        mtx.vin[0].scriptWitness.stack.emplace_back(std::vector<unsigned char>{1});
+        CTransactionRef wit = MakeTransactionRef(mtx);
+        wallet.AddToWallet(wit, TxStateInactive{});
+        const CWalletTx& wtx = wallet.mapWallet.at(no_wit->GetHash());
+        BOOST_CHECK_EQUAL(wtx.m_variants.size(), 2U);
+        BOOST_CHECK(wtx.m_variants.count(no_wit->GetWitnessHash()));
+        BOOST_CHECK(wtx.m_variants.count(wit->GetWitnessHash()));
+
+        CDataStream ss(SER_DISK, CLIENT_VERSION);
+        ss << wtx;
+        CWalletTx copy(nullptr, TxStateInactive{});
+        ss >> copy;
+        BOOST_CHECK_EQUAL(copy.m_variants.size(), 2U);
+        BOOST_CHECK(copy.m_variants.count(no_wit->GetWitnessHash()));
+        BOOST_CHECK(copy.m_variants.count(wit->GetWitnessHash()));
+    }
 }
 
 BOOST_FIXTURE_TEST_CASE(RemoveTxs, TestChain100Setup)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1046,12 +1046,14 @@ CWalletTx* CWallet::AddToWallet(CTransactionRef tx, const TxState& state, const 
             assert(TxStateSerializedIndex(wtx.m_state) == TxStateSerializedIndex(state));
             assert(TxStateSerializedBlockHash(wtx.m_state) == TxStateSerializedBlockHash(state));
         }
-        // If we have a witness-stripped version of this transaction, and we
-        // see a new version with a witness, then we must be upgrading a pre-segwit
-        // wallet.  Store the new version of the transaction with the witness,
-        // as the stripped-version must be invalid.
-        // TODO: Store all versions of the transaction, instead of just one.
-        if (tx->HasWitness() && !wtx.tx->HasWitness()) {
+        if (!wtx.m_variants.count(tx->GetWitnessHash())) {
+            if (tx->HasWitness() && !wtx.tx->HasWitness()) {
+                wtx.SetTx(tx);
+            } else {
+                wtx.m_variants.emplace(tx->GetWitnessHash(), tx);
+            }
+            fUpdated = true;
+        } else if (tx->HasWitness() && !wtx.tx->HasWitness()) {
             wtx.SetTx(tx);
             fUpdated = true;
         }


### PR DESCRIPTION
## Summary
- track multiple witness/non-witness transaction variants in `CWalletTx`
- merge new wallet tx variants without discarding existing ones
- expose available tx variants in `gettransaction` RPC and add persistence test

## Testing
- `cmake .. -GNinja -DBUILD_TEST=ON -DENABLE_WALLET=ON` *(fails: libsecp256k1_zkp >= 0.6.1 not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c47a1db018832ab05794ac79b918b6