### PR TITLE
Add deterministic dividend payout transaction

### DIFF
--- a/src/dividend/dividend.h
+++ b/src/dividend/dividend.h
@@ -3,6 +3,7 @@
 
 #include <consensus/amount.h>
 #include <serialize.h>
+#include <primitives/transaction.h>
 #include <map>
 #include <script/script.h>
 #include <string>
@@ -39,6 +40,12 @@ double CalculateApr(CAmount amount, int blocks_held);
  * @return map of address to payout amount
  */
 Payouts CalculatePayouts(const std::map<std::string, StakeInfo>& stakes, int height, CAmount pool);
+
+/** Build a deterministic payout transaction.
+ * Recipients are sorted by address and a final change output returns
+ * any remaining balance to the dividend pool script.
+ */
+CMutableTransaction BuildPayoutTx(const std::map<std::string, StakeInfo>& stakes, int height, CAmount pool);
 
 //! Constant script used for dividend pool outputs
 inline const CScript& GetDividendScript()


### PR DESCRIPTION
## Summary
- build deterministic quarterly payout transactions with change output
- include payout transactions in new blocks and verify during PoS block checks
- test dividend payout rounding, reorg consistency, and empty pool handling

## Testing
- `cmake .. -DBUILD_BITCOIN_TESTS=ON` *(fails: libsecp256k1_zkp >= 0.6.1 not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c47bea64b4832ab4364971efe05cc6