### PR TITLE
Add dividend info RPC and GUI payout display

### DIFF
--- a/src/qt/dividendpage.cpp
+++ b/src/qt/dividendpage.cpp
@@ -1,14 +1,15 @@
 #include <qt/dividendpage.h>
 
+#include <QStringList>
+#include <interfaces/node.h>
 #include <qt/bitcoinunits.h>
-#include <qt/walletmodel.h>
 #include <qt/clientmodel.h>
 #include <qt/optionsmodel.h>
-#include <interfaces/node.h>
+#include <qt/walletmodel.h>
 #include <wallet/wallet.h>
 
-#include <QVBoxLayout>
 #include <QLabel>
+#include <QVBoxLayout>
 
 DividendPage::DividendPage(const PlatformStyle* platformStyle, QWidget* parent)
     : QWidget(parent), m_platform_style(platformStyle)
@@ -16,8 +17,10 @@ DividendPage::DividendPage(const PlatformStyle* platformStyle, QWidget* parent)
     QVBoxLayout* vbox = new QVBoxLayout(this);
     poolLabel = new QLabel(tr("Pool: 0"), this);
     nextLabel = new QLabel(tr("Next height: n/a"), this);
+    payoutsLabel = new QLabel(tr("Payouts: n/a"), this);
     vbox->addWidget(poolLabel);
     vbox->addWidget(nextLabel);
+    vbox->addWidget(payoutsLabel);
 }
 
 void DividendPage::setClientModel(ClientModel* model)
@@ -37,4 +40,9 @@ void DividendPage::updateData()
     poolLabel->setText(tr("Pool: %1").arg(BitcoinUnits::format(walletModel->getOptionsModel()->getDisplayUnit(), pool)));
     auto next = walletModel->wallet().getNextDividend();
     nextLabel->setText(tr("Next height: %1").arg(next.first));
+    QStringList payouts;
+    for (const auto& [addr, amt] : next.second) {
+        payouts << QString::fromStdString(addr) + ": " + BitcoinUnits::format(walletModel->getOptionsModel()->getDisplayUnit(), amt);
+    }
+    payoutsLabel->setText(tr("Payouts: %1").arg(payouts.join(", ")));
 }

--- a/src/qt/dividendpage.h
+++ b/src/qt/dividendpage.h
@@ -24,6 +24,7 @@ private:
     WalletModel* walletModel{nullptr};
     QLabel* poolLabel;
     QLabel* nextLabel;
+    QLabel* payoutsLabel;
     const PlatformStyle* m_platform_style;
 };
 

--- a/test/functional/rpc_dividend.py
+++ b/test/functional/rpc_dividend.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Test getdividendinfo and getdividendhistory RPCs."""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+QUARTER_BLOCKS = 16200
+
+
+class RpcDividendTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        self.extra_args = [["-dividendpayouts=1"]]
+
+    def run_test(self):
+        node = self.nodes[0]
+        addr = node.getnewaddress()
+        node.generatetoaddress(1, addr)
+
+        info = node.getdividendinfo()
+        assert "pool" in info
+        assert "next_height" in info
+        assert "payouts" in info
+
+        assert_equal(node.getdividendhistory(), {})
+
+        remaining = QUARTER_BLOCKS - node.getblockcount()
+        node.generatetoaddress(remaining, addr)
+
+        hist = node.getdividendhistory()
+        assert str(QUARTER_BLOCKS) in hist
+
+        info2 = node.getdividendinfo()
+        assert info2["next_height"] > QUARTER_BLOCKS
+
+
+if __name__ == '__main__':
+    RpcDividendTest(__file__).main()
+


### PR DESCRIPTION
## Summary
- implement `getdividendinfo` RPC returning pool, next height and payout estimates
- show upcoming dividend payouts in Qt wallet page
- add functional test exercising dividend info and history RPCs

## Testing
- `cmake -B build -GNinja -DBUILD_BITCOIN_QT=OFF` (fails: libsecp256k1_zkp >= 0.6.1 not found)
- `test/functional/test_runner.py rpc_dividend.py` (fails: No such file or directory: '../config.ini')


------
https://chatgpt.com/codex/tasks/task_b_68c48c1d275c832a97683d90f86660e8