### PR TITLE
feat: add actionable staking status with remedies

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1494,8 +1494,17 @@ void BitcoinGUI::updateStakingStatus()
     WalletView* walletView = walletFrame->currentWalletView();
     if (!walletView) return;
     WalletModel* walletModel = walletView->getWalletModel();
-    bool staking = walletModel->wallet().IsStaking();
-    labelStakingText->setText(staking ? tr("Staking: Active") : tr("Staking: Inactive"));
+    QString text;
+    if (walletModel->getEncryptionStatus() == WalletModel::Locked) {
+        text = tr("Staking: Wallet locked");
+    } else if (!walletModel->isStaking()) {
+        text = tr("Staking: Inactive");
+    } else if (walletModel->getStakingStats().staked_balance == 0) {
+        text = tr("Staking: Low weight");
+    } else {
+        text = tr("Staking: Active");
+    }
+    labelStakingText->setText(text);
 #endif
 }
 #endif // ENABLE_WALLET

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -277,6 +277,30 @@
               </property>
              </widget>
             </item>
+            <item row="10" column="0">
+             <widget class="QLabel" name="labelStakeStatusText">
+              <property name="text">
+               <string>Stake status:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="10" column="1">
+             <widget class="QLabel" name="labelStakeStatus">
+              <property name="text">
+               <string>--</string>
+              </property>
+             </widget>
+            </item>
+            <item row="11" column="0" colspan="2">
+             <widget class="QPushButton" name="buttonCopyStakeRemedy">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="text">
+               <string>Copy remedy</string>
+              </property>
+             </widget>
+            </item>
             <item row="0" column="0">
              <widget class="QLabel" name="labelBalanceText">
               <property name="text">

--- a/src/qt/locale/bitcoin_en.ts
+++ b/src/qt/locale/bitcoin_en.ts
@@ -859,6 +859,74 @@
         <source>Recent transactions</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../forms/overviewpage.ui" line="283"/>
+        <source>Stake status:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../forms/overviewpage.ui" line="300"/>
+        <source>Copy remedy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../overviewpage.cpp" line="279"/>
+        <source>Wallet locked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../overviewpage.cpp" line="282"/>
+        <source>Not staking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../overviewpage.cpp" line="284"/>
+        <source>Low weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../overviewpage.cpp" line="286"/>
+        <source>Staking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../overviewpage.cpp" line="287"/>
+        <source>walletpassphrase &lt;pass&gt; &lt;timeout&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../overviewpage.cpp" line="289"/>
+        <source>startstaking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../overviewpage.cpp" line="291"/>
+        <source>add coins to stake</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BitcoinGUI</name>
+    <message>
+        <location filename="../bitcoingui.cpp" line="1499"/>
+        <source>Staking: Wallet locked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../bitcoingui.cpp" line="1501"/>
+        <source>Staking: Inactive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../bitcoingui.cpp" line="1503"/>
+        <source>Staking: Low weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../bitcoingui.cpp" line="1505"/>
+        <source>Staking: Active</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PSBTOperationsDialog</name>

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -41,6 +41,8 @@ public Q_SLOTS:
     void setBalance(const interfaces::WalletBalances& balances);
     void setPrivacy(bool privacy);
     void setStakingStats(const wallet::StakingStats& stats);
+    void updateStakeStatus();
+    void setTestStakeState(const QString& status, const QString& remedy);
 
 Q_SIGNALS:
     void transactionClicked(const QModelIndex &index);
@@ -59,6 +61,7 @@ private:
 
     TxViewDelegate *txdelegate;
     std::unique_ptr<TransactionFilterProxy> filter;
+    QString m_stake_remedy;
 
 private Q_SLOTS:
     void LimitTransactionRows();
@@ -67,6 +70,7 @@ private Q_SLOTS:
     void updateAlerts(const QString &warnings);
     void setMonospacedFont(const QFont&);
     void toggleAutoStake(bool checked);
+    void copyStakeRemedy();
 };
 
 #endif // BITCOIN_QT_OVERVIEWPAGE_H

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -304,6 +304,13 @@ void TestGUI(interfaces::Node& node, const std::shared_ptr<CWallet>& wallet)
     walletModel.pollBalanceChanged(); // Manual balance polling update
     CompareBalance(walletModel, walletModel.wallet().getBalance(), overviewPage.findChild<QLabel*>("labelBalance"));
 
+    // Test stake status copy remedy
+    overviewPage.setTestStakeState("Wallet locked", "walletpassphrase dummy 60");
+    QPushButton* copyStake = overviewPage.findChild<QPushButton*>("buttonCopyStakeRemedy");
+    QVERIFY(copyStake->isEnabled());
+    copyStake->click();
+    QCOMPARE(QApplication::clipboard()->text(), QString("walletpassphrase dummy 60"));
+
     // Check Request Payment button
     ReceiveCoinsDialog receiveCoinsDialog(platformStyle.get());
     receiveCoinsDialog.setModel(&walletModel);


### PR DESCRIPTION
## Summary
- show detailed staking status with copyable remedies on overview
- localize new staking messages
- test remedy copying in headless Qt

## Testing
- `cmake .. -GNinja` *(fails: libsecp256k1_zkp >= 0.6.1 not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c496b5849c832ab42e62a81a67ef80