### PR TITLE
Add BitGold address vectors and prefix rejection tests

### DIFF
--- a/src/test/data/key_io_valid.json
+++ b/src/test/data/key_io_valid.json
@@ -607,4 +607,57 @@
             "isPrivkey": false
         }
     ]
+    ,
+    [
+        "BThvT4vQpb9PVDnPv4DYSLg5WLn2wUAYDX",
+        "76a914ff197b14e502ab41f3bc8ccb48c4abac9eab35bc88ac",
+        {
+            "chain": "main",
+            "isPrivkey": false
+        }
+    ],
+    [
+        "HBZAqTkzwUybCKTobCWVEUtSU4zmohq73W",
+        "a914373b819a068f32b7a6b38b6b38729647cfde01c287",
+        {
+            "chain": "main",
+            "isPrivkey": false
+        }
+    ],
+    [
+        "68Z8LithuLSUv4M4iNpjn7fC3ad6ycCLxefSfUUhX9RQrP9vM2d",
+        "12b004fff7f4b69ef8650e767f18f11ede158148b425660723b9f9a66e61f747",
+        {
+            "chain": "main",
+            "isCompressed": false,
+            "isPrivkey": true
+        }
+    ],
+    [
+        "PeLoQ3uDXzoUDBmZPdKhp8PZkPQMNrM56dEgGpHFr4AkGkbSpcky",
+        "12b004fff7f4b69ef8650e767f18f11ede158148b425660723b9f9a66e61f747",
+        {
+            "chain": "main",
+            "isCompressed": true,
+            "isPrivkey": true
+        }
+    ],
+    [
+        "69ng4Y523YujPkoa3Xe5LE14vDwZKvpZ7Lkc7XUNrsRvHm5WELE",
+        "b524c28b61c9b2c49b2c7dd4c2d75887abb78768c054bd7c01af4029f6c0d117",
+        {
+            "chain": "main",
+            "isCompressed": false,
+            "isPrivkey": true
+        }
+    ],
+    [
+        "PjnbQc8jcFqk7SLYrAEe7rPJHv7ogYYtizBTyoVqV7azCopekuiL",
+        "b524c28b61c9b2c49b2c7dd4c2d75887abb78768c054bd7c01af4029f6c0d117",
+        {
+            "chain": "main",
+            "isCompressed": true,
+            "isPrivkey": true
+        }
+    ]
 ]

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -23,14 +23,17 @@
 using namespace util::hex_literals;
 using util::ToString;
 
-static const std::string strSecret1 = "5HxWvvfubhXpYYpS3tJkw6fq9jE9j18THftkZjHHfmFiWtmAbrj";
-static const std::string strSecret2 = "5KC4ejrDjv152FGwP386VD1i2NYc5KkfSMyv1nGy1VGDxGHqVY3";
-static const std::string strSecret1C = "Kwr371tjA9u2rFSMZjTNun2PXXP3WPZu2afRHTcta6KxEUdm1vEw";
-static const std::string strSecret2C = "L3Hq7a8FEQwJkW1M2GNKDW28546Vp5miewcCzSqUD9kCAXrJdS3g";
-static const std::string addr1 = "1QFqqMUD55ZV3PJEJZtaKCsQmjLT6JkjvJ";
-static const std::string addr2 = "1F5y5E5FMc5YzdJtB9hLaUe43GDxEKXENJ";
-static const std::string addr1C = "1NoJrossxPBKfCHuJXT4HadJrXRE9Fxiqs";
-static const std::string addr2C = "1CRj2HyM1CXWzHAXLQtiGLyggNT9WQqsDs";
+static const std::string strSecret1 = "68Z8LithuLSUv4M4iNpjn7fC3ad6ycCLxefSfUUhX9RQrP9vM2d";
+static const std::string strSecret2 = "69ng4Y523YujPkoa3Xe5LE14vDwZKvpZ7Lkc7XUNrsRvHm5WELE";
+static const std::string strSecret1C = "PeLoQ3uDXzoUDBmZPdKhp8PZkPQMNrM56dEgGpHFr4AkGkbSpcky";
+static const std::string strSecret2C = "PjnbQc8jcFqk7SLYrAEe7rPJHv7ogYYtizBTyoVqV7azCopekuiL";
+static const std::string addr1 = "BThvT4vQpb9PVDnPv4DYSLg5WLn2wUAYDX";
+static const std::string addr2 = "BJY3gwXT77fTSTo3ne2JhcSimsfY12ThGp";
+static const std::string addr1C = "BSFPUXL5htmE72n4v1n2QiRyb8royBjiJu";
+static const std::string addr2C = "BFsoe1RYki7RS7egwuDgPUnMQytjKzDYze";
+static const std::string btcWif = "5HxWvvfubhXpYYpS3tJkw6fq9jE9j18THftkZjHHfmFiWtmAbrj";
+static const std::string btcAddr = "1QFqqMUD55ZV3PJEJZtaKCsQmjLT6JkjvJ";
+static const std::string btcBech32 = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080";
 
 static const std::string strAddressBad = "1HV9Lc3sNHZxwj4Zk6fB38tEmBryq2cBiF";
 
@@ -79,6 +82,15 @@ BOOST_AUTO_TEST_CASE(key_test1)
     BOOST_CHECK(DecodeDestination(addr2)  == CTxDestination(PKHash(pubkey2)));
     BOOST_CHECK(DecodeDestination(addr1C) == CTxDestination(PKHash(pubkey1C)));
     BOOST_CHECK(DecodeDestination(addr2C) == CTxDestination(PKHash(pubkey2C)));
+
+    BOOST_CHECK(EncodeDestination(PKHash(pubkey1))  == addr1);
+    BOOST_CHECK(EncodeDestination(PKHash(pubkey2))  == addr2);
+    BOOST_CHECK(EncodeDestination(PKHash(pubkey1C)) == addr1C);
+    BOOST_CHECK(EncodeDestination(PKHash(pubkey2C)) == addr2C);
+
+    BOOST_CHECK(!DecodeSecret(btcWif).IsValid());
+    BOOST_CHECK(!IsValidDestination(DecodeDestination(btcAddr)));
+    BOOST_CHECK(!IsValidDestination(DecodeDestination(btcBech32)));
 
     for (int n=0; n<16; n++)
     {


### PR DESCRIPTION
## Summary
- add BitGold base58 and WIF vectors and Bech32 prefixes
- ensure key encode/decode round-trips and reject BTC prefixes

## Testing
- `cmake -B build` *(fails: Could not find BoostConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_b_68c496a4eec0832a944871580ddbbc44