### PR TITLE
Define BGD SLIP-44 coin type and unique HD key prefixes

### DIFF
--- a/doc/bip32-prefixes.md
+++ b/doc/bip32-prefixes.md
@@ -1,14 +1,13 @@
 # BIP32 Version Bytes and Coin Type
 
-The following provisional values are assigned for this project.
+The following values are assigned for this project.
 
 | Network  | BIP32 pubkey prefix | BIP32 privkey prefix |
 |----------|--------------------|---------------------|
-| main     | `0x0241C65A`        | `0x0241B21B`        |
-| testnet  | `0x0242C65A`        | `0x0242B21B`        |
-| testnet4 | `0x0243C65A`        | `0x0243B21B`        |
-| signet   | `0x0244C65A`        | `0x0244B21B`        |
-| regtest  | `0x0245C65A`        | `0x0245B21B`        |
+| main     | `0x3252ED54`        | `0x3252F54B`        |
+| testnet  | `0x3352ED54`        | `0x3352F54B`        |
+| testnet4 | `0x3452ED54`        | `0x3452F54B`        |
+| signet   | `0x3552ED54`        | `0x3552F54B`        |
+| regtest  | `0x3652ED54`        | `0x3652F54B`        |
 
-The BIP44 coin type is set to the provisional value `999`. Test
-networks continue to use coin type `1`.
+The BIP44 coin type is `3252`. Test networks continue to use coin type `1`.

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -23,6 +23,9 @@
 
 using util::SplitString;
 
+/** SLIP-44 coin type for BitGold (BGD). */
+const uint32_t BIP44_COIN_TYPE{3252};
+
 void ReadSigNetArgs(const ArgsManager& args, CChainParams::SigNetOptions& options)
 {
     if (!args.GetArgs("-signetseednode").empty()) {

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -29,7 +29,7 @@ const CChainParams &Params();
  */
 void SelectParams(const ChainType chain);
 
-/** Provisional BIP44 coin type. */
-static constexpr uint32_t BIP44_COIN_TYPE{999};
+/** SLIP-44 coin type for BitGold (BGD). */
+extern const uint32_t BIP44_COIN_TYPE;
 
 #endif // BITCOIN_CHAINPARAMS_H

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -190,10 +190,10 @@ public:
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,40);
         base58Prefixes[SECRET_KEY] =     std::vector<unsigned char>(1,153);
 
-        m_bip32_pubkey_prefix = 0x0241C65A;
-        m_bip32_privkey_prefix = 0x0241B21B;
-        base58Prefixes[EXT_PUBLIC_KEY] = {0x02, 0x41, 0xC6, 0x5A};
-        base58Prefixes[EXT_SECRET_KEY] = {0x02, 0x41, 0xB2, 0x1B};
+        m_bip32_pubkey_prefix = 0x3252ED54;
+        m_bip32_privkey_prefix = 0x3252F54B;
+        base58Prefixes[EXT_PUBLIC_KEY] = {0x32, 0x52, 0xED, 0x54};
+        base58Prefixes[EXT_SECRET_KEY] = {0x32, 0x52, 0xF5, 0x4B};
 
         bech32_hrp = "bg";
 
@@ -319,10 +319,10 @@ public:
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1, 65);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1, 78);
         base58Prefixes[SECRET_KEY] = std::vector<unsigned char>(1, 193);
-        m_bip32_pubkey_prefix = 0x0242C65A;
-        m_bip32_privkey_prefix = 0x0242B21B;
-        base58Prefixes[EXT_PUBLIC_KEY] = {0x02, 0x42, 0xC6, 0x5A};
-        base58Prefixes[EXT_SECRET_KEY] = {0x02, 0x42, 0xB2, 0x1B};
+        m_bip32_pubkey_prefix = 0x3352ED54;
+        m_bip32_privkey_prefix = 0x3352F54B;
+        base58Prefixes[EXT_PUBLIC_KEY] = {0x33, 0x52, 0xED, 0x54};
+        base58Prefixes[EXT_SECRET_KEY] = {0x33, 0x52, 0xF5, 0x4B};
 
         bech32_hrp = "tbg";
 
@@ -441,10 +441,10 @@ public:
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1, 65);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1, 78);
         base58Prefixes[SECRET_KEY] = std::vector<unsigned char>(1, 193);
-        m_bip32_pubkey_prefix = 0x0243C65A;
-        m_bip32_privkey_prefix = 0x0243B21B;
-        base58Prefixes[EXT_PUBLIC_KEY] = {0x02, 0x43, 0xC6, 0x5A};
-        base58Prefixes[EXT_SECRET_KEY] = {0x02, 0x43, 0xB2, 0x1B};
+        m_bip32_pubkey_prefix = 0x3452ED54;
+        m_bip32_privkey_prefix = 0x3452F54B;
+        base58Prefixes[EXT_PUBLIC_KEY] = {0x34, 0x52, 0xED, 0x54};
+        base58Prefixes[EXT_SECRET_KEY] = {0x34, 0x52, 0xF5, 0x4B};
 
         bech32_hrp = "tbg";
 
@@ -594,10 +594,10 @@ public:
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1, 111);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1, 196);
         base58Prefixes[SECRET_KEY] = std::vector<unsigned char>(1, 239);
-        m_bip32_pubkey_prefix = 0x0244C65A;
-        m_bip32_privkey_prefix = 0x0244B21B;
-        base58Prefixes[EXT_PUBLIC_KEY] = {0x02, 0x44, 0xC6, 0x5A};
-        base58Prefixes[EXT_SECRET_KEY] = {0x02, 0x44, 0xB2, 0x1B};
+        m_bip32_pubkey_prefix = 0x3552ED54;
+        m_bip32_privkey_prefix = 0x3552F54B;
+        base58Prefixes[EXT_PUBLIC_KEY] = {0x35, 0x52, 0xED, 0x54};
+        base58Prefixes[EXT_SECRET_KEY] = {0x35, 0x52, 0xF5, 0x4B};
 
         bech32_hrp = "sbg";
 
@@ -758,10 +758,10 @@ public:
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1, 111);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1, 196);
         base58Prefixes[SECRET_KEY] = std::vector<unsigned char>(1, 239);
-        m_bip32_pubkey_prefix = 0x0245C65A;
-        m_bip32_privkey_prefix = 0x0245B21B;
-        base58Prefixes[EXT_PUBLIC_KEY] = {0x02, 0x45, 0xC6, 0x5A};
-        base58Prefixes[EXT_SECRET_KEY] = {0x02, 0x45, 0xB2, 0x1B};
+        m_bip32_pubkey_prefix = 0x3652ED54;
+        m_bip32_privkey_prefix = 0x3652F54B;
+        base58Prefixes[EXT_PUBLIC_KEY] = {0x36, 0x52, 0xED, 0x54};
+        base58Prefixes[EXT_SECRET_KEY] = {0x36, 0x52, 0xF5, 0x4B};
 
         bech32_hrp = "rbg";
     }

--- a/src/test/bip32_tests.cpp
+++ b/src/test/bip32_tests.cpp
@@ -202,4 +202,19 @@ BOOST_AUTO_TEST_CASE(bip32_max_depth) {
     BOOST_CHECK(!pubkey_parent.Derive(pubkey_child, 0));
 }
 
+BOOST_AUTO_TEST_CASE(bip32_bgd_prefixes) {
+    SelectParams(ChainType::MAIN);
+    std::vector<std::byte> seed(32, std::byte{0});
+    CExtKey key;
+    key.SetSeed(seed);
+    const std::string priv = EncodeExtKey(key);
+    const std::string pub = EncodeExtPubKey(key.Neuter());
+    BOOST_CHECK(priv.rfind("xprv", 0) != 0);
+    BOOST_CHECK(priv.rfind("tprv", 0) != 0);
+    BOOST_CHECK(pub.rfind("xpub", 0) != 0);
+    BOOST_CHECK(pub.rfind("tpub", 0) != 0);
+    BOOST_CHECK(priv.rfind("Bgd", 0) == 0);
+    BOOST_CHECK(pub.rfind("Bgd", 0) == 0);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary
- register SLIP-44 coin type 3252 for BitGold
- assign dedicated BIP32 xpub/xprv version bytes for all networks
- test that exported HD keys use BGD-specific prefixes

## Testing
- `cmake -S . -B build -GNinja -DBUILD_TESTING=ON -DENABLE_WALLET=ON -DENABLE_GUI=OFF` *(fails: libsecp256k1_zkp >= 0.6.1 not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c496a3e198832a8ae6e67b45590586