### PR TITLE
Add deserialization and verification fuzz targets with CI smoke tests

### DIFF
--- a/ci/test/00_setup_env_native_fuzz.sh
+++ b/ci/test/00_setup_env_native_fuzz.sh
@@ -14,6 +14,7 @@ export NO_DEPENDS=1
 export RUN_UNIT_TESTS=false
 export RUN_FUNCTIONAL_TESTS=false
 export RUN_FUZZ_TESTS=true
+export FUZZ_TARGETS="tx_deserialize block_deserialize bulletproof_decode_verify script_verify"
 export GOAL="all"
 export CI_CONTAINER_CAP="--cap-add SYS_PTRACE"  # If run with (ASan + LSan), the container needs access to ptrace (https://github.com/google/sanitizers/issues/764)
 export BITCOIN_CONFIG="\

--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -203,14 +203,28 @@ if [ "${RUN_TIDY}" = "true" ]; then
 fi
 
 if [ "$RUN_FUZZ_TESTS" = "true" ]; then
-  # shellcheck disable=SC2086
-  LD_LIBRARY_PATH="${DEPENDS_DIR}/${HOST}/lib" \
-  "${BASE_BUILD_DIR}/test/fuzz/test_runner.py" \
-    ${FUZZ_TESTS_CONFIG} \
-    "${MAKEJOBS}" \
-    -l DEBUG \
-    "${DIR_FUZZ_IN}" \
-    --empty_min_time=60
+  if [ -n "$FUZZ_TARGETS" ]; then
+    for target in $FUZZ_TARGETS; do
+      # shellcheck disable=SC2086
+      LD_LIBRARY_PATH="${DEPENDS_DIR}/${HOST}/lib" \
+      "${BASE_BUILD_DIR}/test/fuzz/test_runner.py" \
+        ${FUZZ_TESTS_CONFIG} \
+        "${MAKEJOBS}" \
+        -l DEBUG \
+        "${DIR_FUZZ_IN}" \
+        "$target" \
+        --empty_min_time=60
+    done
+  else
+    # shellcheck disable=SC2086
+    LD_LIBRARY_PATH="${DEPENDS_DIR}/${HOST}/lib" \
+    "${BASE_BUILD_DIR}/test/fuzz/test_runner.py" \
+      ${FUZZ_TESTS_CONFIG} \
+      "${MAKEJOBS}" \
+      -l DEBUG \
+      "${DIR_FUZZ_IN}" \
+      --empty_min_time=60
+  fi
 fi
 
 if [ "$BOOTSTRAP_FRESH_TESTNET" = "true" ]; then

--- a/src/test/fuzz/CMakeLists.txt
+++ b/src/test/fuzz/CMakeLists.txt
@@ -17,11 +17,13 @@ add_executable(fuzz
   bitdeque.cpp
   bitset.cpp
   block.cpp
+  block_deserialize.cpp
   block_header.cpp
   block_index.cpp
   blockfilter.cpp
   bloom_filter.cpp
   buffered_file.cpp
+  bulletproof_decode_verify.cpp
   bulletproof_parse.cpp
   chain.cpp
   checkqueue.cpp
@@ -110,6 +112,7 @@ add_executable(fuzz
   script_parsing.cpp
   script_sigcache.cpp
   script_sign.cpp
+  script_verify.cpp
   scriptnum_ops.cpp
   secp256k1_ec_seckey_import_export_der.cpp
   secp256k1_ecdsa_signature_parse_der_lax.cpp
@@ -124,6 +127,7 @@ add_executable(fuzz
   timeoffsets.cpp
   torcontrol.cpp
   transaction.cpp
+  tx_deserialize.cpp
   txdownloadman.cpp
   tx_in.cpp
   tx_out.cpp

--- a/src/test/fuzz/block_deserialize.cpp
+++ b/src/test/fuzz/block_deserialize.cpp
@@ -1,0 +1,17 @@
+#include <consensus/validation.h>
+#include <primitives/block.h>
+#include <streams.h>
+#include <test/fuzz/fuzz.h>
+
+FUZZ_TARGET(block_deserialize)
+{
+    DataStream ds{buffer};
+    CBlock block;
+    try {
+        ds >> TX_WITH_WITNESS(block);
+    } catch (const std::ios_base::failure&) {
+        return;
+    }
+    (void)block.GetHash();
+    (void)GetBlockWeight(block);
+}

--- a/src/test/fuzz/bulletproof_decode_verify.cpp
+++ b/src/test/fuzz/bulletproof_decode_verify.cpp
@@ -1,0 +1,19 @@
+#include <bulletproofs.h>
+#include <streams.h>
+#include <test/fuzz/fuzz.h>
+
+FUZZ_TARGET(bulletproof_decode_verify)
+{
+#ifdef ENABLE_BULLETPROOFS
+    DataStream ds{buffer};
+    CBulletproof bp;
+    try {
+        ds >> bp;
+    } catch (const std::ios_base::failure&) {
+        return;
+    }
+    (void)VerifyBulletproof(bp);
+#else
+    (void)buffer;
+#endif
+}

--- a/src/test/fuzz/script_verify.cpp
+++ b/src/test/fuzz/script_verify.cpp
@@ -1,0 +1,23 @@
+#include <primitives/transaction.h>
+#include <script/interpreter.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+
+FUZZ_TARGET(script_verify)
+{
+    FuzzedDataProvider fdp{buffer.data(), buffer.size()};
+    const CScript script_sig = ConsumeScript(fdp);
+    const CScript script_pubkey = ConsumeScript(fdp, /*maybe_p2wsh=*/true);
+    const std::optional<CMutableTransaction> mtx = ConsumeDeserializable<CMutableTransaction>(fdp, TX_WITH_WITNESS);
+    if (!mtx) return;
+    const CTransaction tx{*mtx};
+    const unsigned int in = fdp.ConsumeIntegral<unsigned int>();
+    if (in >= tx.vin.size()) return;
+    const unsigned int flags = fdp.ConsumeIntegral<unsigned int>();
+    const CAmount amount = ConsumeMoney(fdp);
+    PrecomputedTransactionData txdata{tx};
+    const CScriptWitness* witness = &tx.vin[in].scriptWitness;
+    TransactionSignatureChecker checker{&tx, in, amount, txdata, MissingDataBehavior::FAIL};
+    (void)VerifyScript(script_sig, script_pubkey, witness, flags, checker);
+}

--- a/src/test/fuzz/tx_deserialize.cpp
+++ b/src/test/fuzz/tx_deserialize.cpp
@@ -1,0 +1,17 @@
+#include <primitives/transaction.h>
+#include <streams.h>
+#include <test/fuzz/fuzz.h>
+
+FUZZ_TARGET(tx_deserialize)
+{
+    DataStream ds{buffer};
+    CMutableTransaction mtx;
+    try {
+        ds >> TX_WITH_WITNESS(mtx);
+    } catch (const std::ios_base::failure&) {
+        return;
+    }
+    const CTransaction tx{mtx};
+    (void)tx.GetHash();
+    (void)tx.GetTotalSize();
+}


### PR DESCRIPTION
## Summary
- add fuzz targets for tx and block deserialization
- fuzz bulletproof decoding/verification
- fuzz VerifyScript and wire up CI smoke tests

## Testing
- `cmake -DBUILD_FUZZ=ON ..` *(fails: libsecp256k1_zkp >= 0.6.1 not found)*
- `test/fuzz/test_runner.py --empty_min_time=1 /tmp/corpus tx_deserialize` *(fails: No such file or directory: '/workspace/bitcoin/test/fuzz/../config.ini')*


------
https://chatgpt.com/codex/tasks/task_b_68c496a2f290832a9048cf4257c88c5a