### PR TITLE
Add DNS seeder crawler and documentation

### DIFF
--- a/contrib/dnsseed/peer_crawler.py
+++ b/contrib/dnsseed/peer_crawler.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""DNS seeder peer crawler with liveness checks.
+
+Resolves peers from configured DNS seeders, tests connectivity and ensures
+peers originate from diverse network groups. If the number of reachable
+peers falls below a configured threshold, an optional alert command is
+executed.
+"""
+
+import argparse
+import asyncio
+import ipaddress
+import socket
+import subprocess
+import sys
+from typing import Dict, List
+
+DEFAULT_SEEDS = [
+    "dnsseed.bitgold.org",
+    "dnsseed.bitgold.com",
+    "dnsseed.bitgold.io",
+]
+DEFAULT_PORT = 8888
+
+
+async def check_peer(addr: str, port: int, timeout: float) -> bool:
+    """Attempt to open a connection to ``addr`` and return ``True`` if successful."""
+    try:
+        reader, writer = await asyncio.wait_for(
+            asyncio.open_connection(addr, port), timeout
+        )
+        writer.close()
+        await writer.wait_closed()
+        return True
+    except Exception:
+        return False
+
+
+def network_group(addr: str) -> str:
+    """Return the network group identifier for ``addr``.
+
+    IPv4 addresses are grouped by /16, IPv6 by /32.
+    """
+    ip = ipaddress.ip_address(addr)
+    if isinstance(ip, ipaddress.IPv4Address):
+        network = ipaddress.ip_network(f"{addr}/16", strict=False)
+    else:
+        network = ipaddress.ip_network(f"{addr}/32", strict=False)
+    return str(network)
+
+
+async def crawl(seeds: List[str], port: int, timeout: float, limit: int) -> List[str]:
+    """Resolve peers from ``seeds`` and return list of reachable peer addresses."""
+    unique: Dict[str, str] = {}
+    tasks: List[asyncio.Task] = []
+
+    for seed in seeds:
+        try:
+            infos = socket.getaddrinfo(seed, port)
+        except socket.gaierror:
+            continue
+        for info in infos:
+            addr = info[4][0]
+            group = network_group(addr)
+            if group in unique:
+                continue
+            unique[group] = addr
+            tasks.append(asyncio.create_task(check_peer(addr, port, timeout)))
+            if limit and len(unique) >= limit:
+                break
+
+    results = await asyncio.gather(*tasks)
+    reachable = [addr for addr, ok in zip(unique.values(), results) if ok]
+    return reachable
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="DNS seeder peer crawler with liveness checks",
+    )
+    parser.add_argument(
+        "--seeds",
+        nargs="+",
+        default=DEFAULT_SEEDS,
+        help="DNS seeder hostnames to query",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=DEFAULT_PORT,
+        help="peer port to test",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=3.0,
+        help="connection timeout in seconds",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=50,
+        help="maximum unique peers to test",
+    )
+    parser.add_argument(
+        "--min-peers",
+        type=int,
+        default=8,
+        help="minimum reachable peers before alerting",
+    )
+    parser.add_argument(
+        "--alert-cmd",
+        help="shell command to execute when reachable peers drop below --min-peers",
+    )
+
+    args = parser.parse_args()
+    reachable = asyncio.run(crawl(args.seeds, args.port, args.timeout, args.limit))
+    print(f"reachable peers: {len(reachable)}")
+
+    if len(reachable) < args.min_peers:
+        print(
+            f"ALERT: reachable peers below threshold ({len(reachable)} < {args.min_peers})",
+            file=sys.stderr,
+        )
+        if args.alert_cmd:
+            subprocess.call(args.alert_cmd, shell=True)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    raise SystemExit(main())

--- a/doc/dns-seeding.md
+++ b/doc/dns-seeding.md
@@ -1,0 +1,42 @@
+# DNS Seeding Operations
+
+This document describes how to operate DNS seeders for the BitGold network.
+Operating several independent seeders provides robustness for new nodes
+searching for peers. At least three seeders should be deployed and maintained
+by different operators.
+
+## Deploying seeders
+
+The reference network currently uses the following public seeders:
+
+- `dnsseed.bitgold.org`
+- `dnsseed.bitgold.com`
+- `dnsseed.bitgold.io`
+
+Additional seeders may be added as the network grows. Seeders should run a
+crawler that collects reachable peers and exports them via DNS records.
+
+## Peer crawler and liveness checks
+
+The `contrib/dnsseed/peer_crawler.py` script automates crawling and basic
+health checks. It resolves peers from the configured seeders, connects to the
+peers to verify they are reachable and keeps one peer per network group to
+promote diversity. If the number of reachable peers drops below a configured
+minimum, an optional alert command is executed.
+
+Example usage:
+
+```sh
+python3 contrib/dnsseed/peer_crawler.py --min-peers 12 --alert-cmd 'echo alert'
+```
+
+The script exits with a non-zero status when the threshold is not met, making
+it suitable for integration in cron jobs or other monitoring systems.
+
+## Alerts
+
+Operators should configure `--alert-cmd` to trigger notifications (e.g. send an
+email or push message) whenever the script detects insufficient reachable peers.
+
+Keeping the seeders responsive and populated with diverse peers ensures new
+nodes can quickly join the network.


### PR DESCRIPTION
## Summary
- add a peer crawler for DNS seeders with diversity and liveness checks
- document seeder operation and monitoring

## Testing
- `python3 test/lint/lint-python.py contrib/dnsseed/peer_crawler.py` *(skipped: lief not installed)*
- `python3 -m py_compile contrib/dnsseed/peer_crawler.py`
- `python3 test/lint/check-doc.py doc/dns-seeding.md` *(fails: Please document the following arguments: {'-hybridmempool', '-stakesplitthreshold'})*

------
https://chatgpt.com/codex/tasks/task_b_68c496a04c30832aa5ab5ed71b56a467