### PR TITLE
Add supply cap test

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -122,6 +122,7 @@ add_executable(test_bitcoin
   util_tests.cpp
   util_threadnames_tests.cpp
   util_trace_tests.cpp
+  validation/reward_schedule_tests.cpp
   validation_block_tests.cpp
   validation_chainstate_tests.cpp
   validation_chainstatemanager_tests.cpp

--- a/src/test/validation/reward_schedule_tests.cpp
+++ b/src/test/validation/reward_schedule_tests.cpp
@@ -1,0 +1,25 @@
+#include <chainparams.h>
+#include <consensus/amount.h>
+#include <test/util/setup_common.h>
+#include <util/chaintype.h>
+#include <validation.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(reward_schedule_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(total_supply_below_cap)
+{
+    const auto params = CreateChainParams(*m_node.args, ChainType::MAIN);
+    const auto& consensus = params->GetConsensus();
+
+    CAmount total{0};
+    for (int height = 0;; ++height) {
+        const CAmount subsidy{GetBlockSubsidy(height, consensus)};
+        if (subsidy == 0) break;
+        total += subsidy;
+    }
+    BOOST_CHECK_LE(total, 8'000'000 * COIN);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary
- add reward schedule unit test to verify supply stays under 8M BGD
- include test in test suite build

## Testing
- `cmake -S . -B build -GNinja` *(fails: libsecp256k1_zkp >= 0.6.1 not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c496a01164832a811553ee88b8efc0