### PR TITLE
Refactor PoS stake consensus to use lightweight modifier interface

### DIFF
--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -707,7 +707,8 @@ bool CreatePosBlock(wallet::CWallet& wallet)
     block.hashMerkleRoot = BlockMerkleRoot(block);
 
     if (!ContextualCheckProofOfStake(block, pindexPrev, chainstate.CoinsTip(),
-                                     chainstate.m_chain, consensus)) {
+                                     chainstate.m_chain, *node_context->stake_modman,
+                                     consensus)) {
         return false;
     }
 

--- a/src/node/stake_modifier_manager.h
+++ b/src/node/stake_modifier_manager.h
@@ -7,6 +7,7 @@
 #include <optional>
 #include <uint256.h>
 #include <validationinterface.h>
+#include <pos/stake_modifier_interface.h>
 
 class CBlockIndex;
 class ChainstateManager;
@@ -17,7 +18,7 @@ namespace node {
 /**
  * Manages cached stake modifiers for consensus and networking.
  */
-class StakeModifierManager : public CValidationInterface
+class StakeModifierManager : public CValidationInterface, public StakeModifierProvider
 {
 private:
     struct ModifierEntry {
@@ -37,14 +38,14 @@ public:
     std::optional<uint256> GetModifier(const uint256& block_hash) const;
 
     /** Return the current stake modifier. */
-    uint256 GetCurrentModifier() const;
+    uint256 GetCurrentModifier() const override;
 
     /**
      * Return the current stake modifier, refreshing it if the provided time
      * exceeds the refresh interval (v3 algorithm).
      */
     uint256 GetDynamicModifier(const CBlockIndex* pindexPrev, unsigned int nTime,
-                               const Consensus::Params& params);
+                               const Consensus::Params& params) override;
 
     /** Update the modifier on block connect. */
     void UpdateOnConnect(const CBlockIndex* pindex, const Consensus::Params& params);

--- a/src/pos/stake.cpp
+++ b/src/pos/stake.cpp
@@ -1,7 +1,6 @@
 #include <pos/stake.h>
 #include <pos/difficulty.h>
 #include <pos/stakemodifier.h>
-#include <node/stake_modifier_manager.h>
 
 #include <arith_uint256.h>
 #include <hash.h>
@@ -9,7 +8,6 @@
 #include <pubkey.h>
 #include <util/overflow.h>
 #include <logging.h>
-#include <validation.h>
 #include <algorithm>
 
 #include <cassert>
@@ -113,7 +111,7 @@ bool CheckStakeKernelHash(const CBlockIndex* pindexPrev,
                           CAmount amount,
                           const COutPoint& prevout,
                           unsigned int nTimeTx,
-                          node::StakeModifierManager& stake_modman,
+                          StakeModifierProvider& stake_modman,
                           uint256& hashProofOfStake,
                           bool fPrintProofOfStake,
                           const Consensus::Params& params)
@@ -173,6 +171,7 @@ bool ContextualCheckProofOfStake(const CBlock& block,
                                  const CBlockIndex* pindexPrev,
                                  const CCoinsViewCache& view,
                                  const CChain& chain,
+                                 StakeModifierProvider& stake_modman,
                                  const Consensus::Params& params)
 {
     if (!pindexPrev) return false;
@@ -221,7 +220,7 @@ bool ContextualCheckProofOfStake(const CBlock& block,
     if (!CheckStakeKernelHash(pindexPrev, nBits,
                               pindexFrom->GetBlockHash(), nTimeBlockFrom,
                               coin.out.nValue, txin.prevout,
-                              block.nTime, hashProofOfStake, false, params)) {
+                              block.nTime, stake_modman, hashProofOfStake, false, params)) {
         return false;
     }
 

--- a/src/pos/stake.h
+++ b/src/pos/stake.h
@@ -5,11 +5,11 @@
 #include <chain.h>
 #include <coins.h>
 #include <consensus/params.h>
-#include <node/stake_modifier_manager.h>
 #include <primitives/block.h>
 #include <uint256.h>
 #include <arith_uint256.h>
 #include <util/time.h>
+#include <pos/stake_modifier_interface.h>
 
 class CBlockIndex;
 
@@ -23,7 +23,7 @@ arith_uint256 MultiplyStakeTarget(const arith_uint256& bnTarget, CAmount amount)
 bool CheckStakeKernelHash(const CBlockIndex* pindexPrev, unsigned int nBits,
                           uint256 hashBlockFrom, unsigned int nTimeBlockFrom,
                           CAmount amount, const COutPoint& prevout,
-                          unsigned int nTimeTx, node::StakeModifierManager& stake_modman,
+                          unsigned int nTimeTx, StakeModifierProvider& stake_modman,
                           uint256& hashProofOfStake, bool fPrintProofOfStake,
                           const Consensus::Params& params);
 
@@ -35,6 +35,7 @@ bool CheckStakeKernelHash(const CBlockIndex* pindexPrev, unsigned int nBits,
  */
 bool ContextualCheckProofOfStake(const CBlock& block, const CBlockIndex* pindexPrev,
                                  const CCoinsViewCache& view, const CChain& chain,
+                                 StakeModifierProvider& stake_modman,
                                  const Consensus::Params& params);
 
 /**

--- a/src/pos/stake_modifier_interface.h
+++ b/src/pos/stake_modifier_interface.h
@@ -1,0 +1,18 @@
+#ifndef BITCOIN_POS_STAKE_MODIFIER_INTERFACE_H
+#define BITCOIN_POS_STAKE_MODIFIER_INTERFACE_H
+
+#include <uint256.h>
+
+class CBlockIndex;
+namespace Consensus { struct Params; }
+
+/** Interface for providing stake modifier data to consensus checks. */
+class StakeModifierProvider {
+public:
+    virtual ~StakeModifierProvider() = default;
+    virtual uint256 GetCurrentModifier() const = 0;
+    virtual uint256 GetDynamicModifier(const CBlockIndex* pindexPrev, unsigned int nTime,
+                                       const Consensus::Params& params) = 0;
+};
+
+#endif // BITCOIN_POS_STAKE_MODIFIER_INTERFACE_H

--- a/src/wallet/bitgoldstaker.cpp
+++ b/src/wallet/bitgoldstaker.cpp
@@ -272,7 +272,9 @@ coinstake.vout.emplace_back(dividend_reward, dividendScript);
                             LOCK(cs_main);
                             if (!ContextualCheckProofOfStake(block, pindexPrev,
                                                              chainman.ActiveChainstate().CoinsTip(),
-                                                             chainman.ActiveChain(), consensus)) {
+                                                             chainman.ActiveChain(),
+                                                             *node_context->stake_modman,
+                                                             consensus)) {
                                 LogDebug(BCLog::STAKING, "ThreadStakeMiner: produced block failed CheckProofOfStake\n");
                                 continue;
                             }


### PR DESCRIPTION
## Summary
- decouple PoS stake checks from node layer by introducing a `StakeModifierProvider` interface
- remove node and validation includes from consensus stake code
- update miner, wallet staker, and tests to supply stake modifier context

## Testing
- `cmake .. -DBUILD_GUI=OFF` *(fails: libsecp256k1_zkp >= 0.6.1 not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c49f5a21b8832abd896eeefcd9e192