### PR TITLE
Relocate dividend module into consensus divisons directory

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -324,7 +324,7 @@ add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
   rpc/bulletproof.cpp
   rpc/txoutproof.cpp
   rpc/dividend.cpp
-  dividend/dividend.cpp
+  consensus/dividends/dividend.cpp
   $<$<TARGET_EXISTS:bitcoin_wallet>:rpc/staking.cpp>
   script/sigcache.cpp
   signet.cpp

--- a/src/consensus/dividends/dividend.cpp
+++ b/src/consensus/dividends/dividend.cpp
@@ -1,7 +1,7 @@
 // Bitcoin Core's dividend module uses integer arithmetic to avoid floating
 // point rounding errors when calculating payouts.
 
-#include <dividend/dividend.h>
+#include <consensus/dividends/dividend.h>
 
 #include <algorithm>
 #include <vector>

--- a/src/consensus/dividends/dividend.h
+++ b/src/consensus/dividends/dividend.h
@@ -1,5 +1,5 @@
-#ifndef BITCOIN_DIVIDEND_DIVIDEND_H
-#define BITCOIN_DIVIDEND_DIVIDEND_H
+#ifndef BITCOIN_CONSENSUS_DIVIDENDS_DIVIDEND_H
+#define BITCOIN_CONSENSUS_DIVIDENDS_DIVIDEND_H
 
 #include <consensus/amount.h>
 #include <consensus/dividends/schedule.h>
@@ -59,4 +59,4 @@ inline const CScript& GetDividendScript()
 
 } // namespace dividend
 
-#endif // BITCOIN_DIVIDEND_DIVIDEND_H
+#endif // BITCOIN_CONSENSUS_DIVIDENDS_DIVIDEND_H

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -3,7 +3,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <dividend/dividend.h>
+#include <consensus/dividends/dividend.h>
 #include <consensus/dividends/schedule.h>
 #include <node/miner.h>
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -53,7 +53,7 @@
 #include <validation.h>
 #include <validationinterface.h>
 #include <versionbits.h>
-#include <dividend/dividend.h>
+#include <consensus/dividends/dividend.h>
 
 #include <cstdint>
 

--- a/src/rpc/dividend.cpp
+++ b/src/rpc/dividend.cpp
@@ -1,7 +1,7 @@
 #include <bitgold-build-config.h> // IWYU pragma: keep
 
 #include <common/args.h>
-#include <dividend/dividend.h>
+#include <consensus/dividends/dividend.h>
 #include <rpc/server.h>
 #include <rpc/server_util.h>
 #include <rpc/util.h>

--- a/src/test/coinstake_rewards_tests.cpp
+++ b/src/test/coinstake_rewards_tests.cpp
@@ -1,6 +1,6 @@
 #include <chainparams.h>
 #include <consensus/validation.h>
-#include <dividend/dividend.h>
+#include <consensus/dividends/dividend.h>
 #include <consensus/merkle.h>
 #include <primitives/block.h>
 #include <script/script.h>

--- a/src/test/dividend_tests.cpp
+++ b/src/test/dividend_tests.cpp
@@ -1,5 +1,5 @@
 #include <boost/test/unit_test.hpp>
-#include <dividend/dividend.h>
+#include <consensus/dividends/dividend.h>
 #include <consensus/dividends/schedule.h>
 #include <uint256.h>
 #include <primitives/transaction.h>

--- a/src/test/fuzz/dividend_payout.cpp
+++ b/src/test/fuzz/dividend_payout.cpp
@@ -1,4 +1,4 @@
-#include <dividend/dividend.h>
+#include <consensus/dividends/dividend.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 

--- a/src/test/validation_tests.cpp
+++ b/src/test/validation_tests.cpp
@@ -17,7 +17,7 @@
 #include <validation.h>
 #include <script/script.h>
 #include <arith_uint256.h>
-#include <dividend/dividend.h>
+#include <consensus/dividends/dividend.h>
 #include <cstring>
 
 #ifdef ENABLE_BULLETPROOFS

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -9,7 +9,7 @@
 #include <coins.h>
 #include <dbwrapper.h>
 #include <consensus/amount.h>
-#include <dividend/dividend.h>
+#include <consensus/dividends/dividend.h>
 #include <kernel/cs_main.h>
 #include <sync.h>
 #include <util/fs.h>

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -8,7 +8,7 @@
 #include <common/args.h>
 #include <kernel/stake.h>
 #include <pos/slashing.h>
-#include <dividend/dividend.h>
+#include <consensus/dividends/dividend.h>
 #include <consensus/dividends/schedule.h>
 #include <pow.h>
 #include <validation.h>

--- a/src/validation.h
+++ b/src/validation.h
@@ -34,7 +34,7 @@
 #include <util/time.h>
 #include <util/translation.h>
 #include <versionbits.h>
-#include <dividend/dividend.h>
+#include <consensus/dividends/dividend.h>
 #include <consensus/dividends/schedule.h>
 
 #include <atomic>

--- a/src/wallet/bitgoldstaker.cpp
+++ b/src/wallet/bitgoldstaker.cpp
@@ -3,7 +3,7 @@
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
 #include <consensus/merkle.h>
-#include <dividend/dividend.h>
+#include <consensus/dividends/dividend.h>
 #include <interfaces/chain.h>
 #include <key.h>
 #include <node/context.h>

--- a/src/wallet/rpc/dividend.cpp
+++ b/src/wallet/rpc/dividend.cpp
@@ -1,6 +1,6 @@
 #include <bitgold-build-config.h> // IWYU pragma: keep
 
-#include <dividend/dividend.h>
+#include <consensus/dividends/dividend.h>
 #include <rpc/server_util.h>
 #include <rpc/util.h>
 #include <validation.h>

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -7,7 +7,7 @@
 #include <wallet/spend.h>
 #include <wallet/blinding.h>
 
-#include <dividend/dividend.h>
+#include <consensus/dividends/dividend.h>
 #include <wallet/receive.h>
 #include <policy/policy.h>
 #ifdef ENABLE_BULLETPROOFS


### PR DESCRIPTION
## Summary
- move dividend implementation into `src/consensus/dividends/`
- update all includes to `<consensus/dividends/dividend.h>`
- compile new source path in `src/CMakeLists.txt`

## Testing
- `cmake -S . -B build` *(fails: libsecp256k1_zkp >= 0.6.1 not found)*
- `rg "dividend/dividend.h" -n`

------
https://chatgpt.com/codex/tasks/task_b_68c49f5346d4832a9959fdee81b14e8a