### PR TITLE
refactor: remove unused standard script include

### DIFF
--- a/src/pos/stake.cpp
+++ b/src/pos/stake.cpp
@@ -4,7 +4,6 @@
 #include <arith_uint256.h>
 #include <hash.h>
 #include <primitives/transaction.h>
-#include <script/standard.h>
 #include <util/overflow.h>
 #include <logging.h>
 


### PR DESCRIPTION
## Summary
- drop unused script/standard.h include from stake.cpp

## Testing
- `cmake -S . -B build`
- `/usr/bin/c++ -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -DBOOST_NO_CXX98_FUNCTION_BASE -I/workspace/bitcoin/build/src -I/workspace/bitcoin/src -I/workspace/bitcoin/src/leveldb/include -I/workspace/bitcoin/src/minisketch/include -I/workspace/bitcoin/src/univalue/include -O2 -g -std=c++20 -fPIC -fno-extended-identifiers -fdebug-prefix-map=/workspace/bitcoin/src=. -fmacro-prefix-map=/workspace/bitcoin/src=. -fstack-reuse=none -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -Wstack-protector -fstack-protector-all -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wformat -Wformat-security -Wvla -Wredundant-decls -Wdate-time -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Woverloaded-virtual -Wsuggest-override -Wimplicit-fallthrough -Wunreachable-code -Wbidi-chars=any -Wundef -Wno-unused-parameter -o build/test_stake.o -c src/pos/stake.cpp` *(fails: ‘CHashWriter’ was not declared)*


------
https://chatgpt.com/codex/tasks/task_b_68c5942dffb0832aaf8197b2beef145d