### PR TITLE
doc: mention Boost requirement for CMake builds

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -46,7 +46,7 @@ Build requirements:
 
     sudo apt-get install build-essential cmake pkgconf python3
 
-Now, you can either build from self-compiled [depends](#dependencies) or install the required dependencies:
+Now, you can either build from self-compiled [depends](#dependencies) or install the required dependencies (including Boost \>=1.73):
 
     sudo apt-get install libevent-dev libboost-dev
 


### PR DESCRIPTION
## Summary
- clarify that CMake builds require Boost >=1.73 on Debian/Ubuntu

## Testing
- `python3 test/lint/check-doc.py`
- `cmake -S . -B build`


------
https://chatgpt.com/codex/tasks/task_b_68c59767c544832a8e5aa0485f663ff6