### PR TITLE
Adjust PoS target spacing to 8 minute blocks

### DIFF
--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -108,7 +108,7 @@ public:
         consensus.nStakeMinAge = 60 * 60;
         consensus.nStakeModifierInterval = 60 * 60;
         consensus.posLimit = consensus.powLimit;
-        consensus.nStakeTargetSpacing = 16;
+        consensus.nStakeTargetSpacing = 8 * 60;
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.enforce_BIP94 = false;
         consensus.fPowNoRetargeting = false;
@@ -230,7 +230,7 @@ public:
         consensus.nStakeMinAge = 60 * 60;
         consensus.nStakeModifierInterval = 60 * 60;
         consensus.posLimit = consensus.powLimit;
-        consensus.nStakeTargetSpacing = 16;
+        consensus.nStakeTargetSpacing = 8 * 60;
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.enforce_BIP94 = false;
         consensus.fPowNoRetargeting = false;
@@ -375,7 +375,7 @@ public:
         consensus.MinBIP9WarningHeight = 0;
         consensus.powLimit = uint256{"00000377ae000000000000000000000000000000000000000000000000000000"};
         consensus.posLimit = consensus.powLimit;
-        consensus.nStakeTargetSpacing = 16;
+        consensus.nStakeTargetSpacing = 8 * 60;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
@@ -466,7 +466,7 @@ public:
         consensus.nStakeMinAge = 60 * 60;
         consensus.nStakeModifierInterval = 60 * 60;
         consensus.posLimit = consensus.powLimit;
-        consensus.nStakeTargetSpacing = 16;
+        consensus.nStakeTargetSpacing = 8 * 60;
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.enforce_BIP94 = opts.enforce_bip94;
         consensus.fPowNoRetargeting = true;

--- a/test/functional/feature_posv3.py
+++ b/test/functional/feature_posv3.py
@@ -19,6 +19,8 @@ from test_framework.script import CScript
 from test_framework.util import assert_equal
 
 STAKE_TIMESTAMP_MASK = 0xF
+TIMESTAMP_GRANULARITY = STAKE_TIMESTAMP_MASK + 1
+TARGET_SPACING = 8 * 60
 MIN_STAKE_AGE = 60 * 60
 
 
@@ -69,9 +71,10 @@ class PosV3Test(BitcoinTestFramework):
         stake_block_hash = node.gettransaction(txid)['blockhash']
         stake_time = node.getblock(stake_block_hash)['time']
 
-        ntime = prev_time + 16
+        ntime = prev_time + TARGET_SPACING
+        ntime = (ntime + STAKE_TIMESTAMP_MASK) & ~STAKE_TIMESTAMP_MASK
         while not check_kernel(prev_hash, prev_height, prev_time, nbits, stake_block_hash, stake_time, amount, prevout, ntime):
-            ntime += 16
+            ntime += TIMESTAMP_GRANULARITY
 
         script = CScript(bytes.fromhex(unspent['scriptPubKey']))
 

--- a/test/functional/pos_block_staking.py
+++ b/test/functional/pos_block_staking.py
@@ -16,6 +16,8 @@ from test_framework.script import CScript
 from test_framework.util import assert_equal
 
 STAKE_TIMESTAMP_MASK = 0xF
+TIMESTAMP_GRANULARITY = STAKE_TIMESTAMP_MASK + 1
+TARGET_SPACING = 8 * 60
 MIN_STAKE_AGE = 60 * 60
 
 
@@ -68,7 +70,8 @@ class PosBlockStakingTest(BitcoinTestFramework):
         stake_block_hash = node.gettransaction(txid)["blockhash"]
         stake_time = node.getblock(stake_block_hash)["time"]
 
-        ntime = prev_time + 16
+        ntime = prev_time + TARGET_SPACING
+        ntime = (ntime + STAKE_TIMESTAMP_MASK) & ~STAKE_TIMESTAMP_MASK
         while not check_kernel(
             prev_hash,
             prev_height,
@@ -80,7 +83,7 @@ class PosBlockStakingTest(BitcoinTestFramework):
             prevout,
             ntime,
         ):
-            ntime += 16
+            ntime += TIMESTAMP_GRANULARITY
 
         script = CScript(bytes.fromhex(unspent["scriptPubKey"]))
         coinstake = CTransaction()

--- a/test/functional/pos_reorg.py
+++ b/test/functional/pos_reorg.py
@@ -16,6 +16,8 @@ from test_framework.script import CScript
 from test_framework.util import assert_equal
 
 STAKE_TIMESTAMP_MASK = 0xF
+TIMESTAMP_GRANULARITY = STAKE_TIMESTAMP_MASK + 1
+TARGET_SPACING = 8 * 60
 MIN_STAKE_AGE = 60 * 60
 
 
@@ -60,7 +62,8 @@ def stake_block(node):
     stake_block_hash = node.gettransaction(txid)["blockhash"]
     stake_time = node.getblock(stake_block_hash)["time"]
 
-    ntime = prev_time + 16
+    ntime = prev_time + TARGET_SPACING
+    ntime = (ntime + STAKE_TIMESTAMP_MASK) & ~STAKE_TIMESTAMP_MASK
     while not check_kernel(
         prev_hash,
         prev_height,
@@ -72,7 +75,7 @@ def stake_block(node):
         prevout,
         ntime,
     ):
-        ntime += 16
+        ntime += TIMESTAMP_GRANULARITY
 
     script = CScript(bytes.fromhex(unspent["scriptPubKey"]))
     coinstake = CTransaction()

--- a/test/functional/wallet_stake_miner.py
+++ b/test/functional/wallet_stake_miner.py
@@ -6,6 +6,8 @@ from test_framework.messages import COIN, hash256, uint256_from_compact
 from test_framework.util import assert_equal
 
 STAKE_TIMESTAMP_MASK = 0xF
+TIMESTAMP_GRANULARITY = STAKE_TIMESTAMP_MASK + 1
+TARGET_SPACING = 8 * 60
 MIN_STAKE_AGE = 60 * 60
 
 
@@ -39,7 +41,8 @@ class StakeMinerLifecycleTest(BitcoinTestFramework):
         self.num_nodes = 1
 
     def find_ntime(self, prev_hash, prev_height, prev_time, nbits, stake_hash, stake_time, amount, prevout):
-        ntime = prev_time + 16
+        ntime = prev_time + TARGET_SPACING
+        ntime = (ntime + STAKE_TIMESTAMP_MASK) & ~STAKE_TIMESTAMP_MASK
         while not check_kernel(
             prev_hash,
             prev_height,
@@ -51,7 +54,7 @@ class StakeMinerLifecycleTest(BitcoinTestFramework):
             prevout,
             ntime,
         ):
-            ntime += 16
+            ntime += TIMESTAMP_GRANULARITY
         return ntime
 
     def run_test(self):


### PR DESCRIPTION
## Summary
- set the PoS target spacing to 8 minutes for each chain configuration
- update PoS functional tests and utilities to search for kernels on 8 minute intervals

## Testing
- `cmake --build build` *(fails: build currently breaks in src/pos/stake.cpp and src/pos/stakemodifier_manager.cpp)*

------
https://chatgpt.com/codex/tasks/task_b_68cd525db1c4832a93f3f5eda02855e2